### PR TITLE
Review .travis.yml to add import path instruction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,7 @@ addons:
     packages:
       - mongodb-org-server
 
-before_install:
-  # fix travis working folder (see http://www.ruflin.com/2015/08/13/fix-for-travis-ci-failure-in-forked-golang-repositories/)
-  - mkdir -p $HOME/gopath/src/github.com/tidepool-org/shoreline
-  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/tidepool-org/shoreline/
-  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/tidepool-org/shoreline
-  - cd $HOME/gopath/src/github.com/tidepool-org/shoreline
+go_import_path: github.com/tidepool-org/shoreline
 
 deploy:
   # Control deployment by setting a value for `on`. Setting the `branch`


### PR DESCRIPTION
The Travis build is problematic by default because of the way Go imports the packages and dependencies for the build (see http://www.ruflin.com/2015/08/13/fix-for-travis-ci-failure-in-forked-golang-repositories/). Travis code was changed to prevent from this bad behaviour.
However, this piece of code was problematic as the Travis setup was done twice.
This PR is a proposal for changing this "before_install" script by the "go_import_path" instruction (https://docs.travis-ci.com/user/languages/go/#go-import-path).

Fix #6 