### PR TITLE
PT-158 Shoreline Update with new token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 deploy/
 dist/
+.vscode/
 
+*.exe
 artifact_go.sh

--- a/env.sh
+++ b/env.sh
@@ -21,7 +21,7 @@ export TIDEPOOL_SHORELINE_SERVICE='{
         "connectionString": "mongodb://localhost/user"
     },
     "user": {
-        "serverSecret": "This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy",
+        "secrets": [{\"secret\": \"default\", \"pass\": \"xxxxxxxxx\"}, {\"secret\": \"product_website\", \"pass\": \"xxxxxxxxx\"}],
         "apiSecret": "This is a local API secret for everyone. BsscSHqSHiwrBMJsEGqbvXiuIUPAjQXU",
         "longTermKey": "abcdefghijklmnopqrstuvwxyz",
         "longTermDaysDuration": 30,

--- a/shoreline.go
+++ b/shoreline.go
@@ -75,7 +75,7 @@ func main() {
 	 * User-Api setup
 	 */
 
-	log.Print(shoreline_service_prefix, "adding", user.USER_API_PREFIX)
+	log.Print(shoreline_service_prefix, "adding ", user.USER_API_PREFIX)
 
 	userapi := user.InitApi(config.User, user.NewMongoStoreClient(&config.Mongo), highwater)
 	userapi.SetHandlers("", rtr)
@@ -88,14 +88,14 @@ func main() {
 		WithTokenProvider(userClient).
 		Build()
 
-	log.Print(shoreline_service_prefix, "adding", "permsClient")
+	log.Print(shoreline_service_prefix, "adding ", "permsClient")
 	userapi.AttachPerms(permsClient)
 
 	/*
 	 * Oauth setup
 	 */
 
-	log.Print(shoreline_service_prefix, "adding", oauth2.OAUTH2_API_PREFIX)
+	log.Print(shoreline_service_prefix, "adding ", oauth2.OAUTH2_API_PREFIX)
 
 	oauthapi := oauth2.InitApi(config.Oauth2, oauth2.NewOAuthStorage(&config.Mongo), userClient, permsClient)
 	oauthapi.SetHandlers("", rtr)

--- a/user/api.go
+++ b/user/api.go
@@ -33,26 +33,26 @@ type (
 		mailchimpManager mailchimp.Manager
 	}
 	Secret struct {
-		Secret           string `json:"secret"`
-		Pass		      string `json:"pass"`
+		Secret string `json:"secret"`
+		Pass   string `json:"pass"`
 	}
 	ApiConfig struct {
 		//used for services
-		secrets 			 	[]Secret `json:"secrets"`
-		ServerSecrets			map[string]string
-		LongTermKey          	string `json:"longTermKey"`
-		LongTermDaysDuration 	int    `json:"longTermDaysDuration"`
+		secrets              []Secret `json:"secrets"`
+		ServerSecrets        map[string]string
+		LongTermKey          string `json:"longTermKey"`
+		LongTermDaysDuration int    `json:"longTermDaysDuration"`
 		//so we can change the default lifetime of the token
 		//we use seconds, this also helps for testing as you can time it out easily
-		TokenDurationSecs 		int64 `json:"tokenDurationSecs"`
+		TokenDurationSecs int64 `json:"tokenDurationSecs"`
 		//used for pw
-		Salt 					string `json:"salt"`
+		Salt string `json:"salt"`
 		//used for token
-		Secret 					string `json:"apiSecret"`
+		Secret string `json:"apiSecret"`
 		//allows for the skipping of verification for testing
-		VerificationSecret 		string           `json:"verificationSecret"`
-		ClinicDemoUserID   		string           `json:"clinicDemoUserId"`
-		Mailchimp          		mailchimp.Config `json:"mailchimp"`
+		VerificationSecret string           `json:"verificationSecret"`
+		ClinicDemoUserID   string           `json:"clinicDemoUserId"`
+		Mailchimp          mailchimp.Config `json:"mailchimp"`
 	}
 	varsHandler func(http.ResponseWriter, *http.Request, map[string]string)
 )
@@ -90,8 +90,8 @@ const (
 	STATUS_UNAUTHORIZED          = "Not authorized for requested operation"
 	STATUS_NO_QUERY              = "A query must be specified"
 	STATUS_INVALID_ROLE          = "The role specified is invalid"
-	STATUS_OK        			 = "OK"
-	STATUS_NO_EXPECTED_PWD		 = "No expected password is found"
+	STATUS_OK                    = "OK"
+	STATUS_NO_EXPECTED_PWD       = "No expected password is found"
 )
 
 func InitApi(cfg ApiConfig, store Storage, metrics highwater.Client) *Api {
@@ -555,7 +555,7 @@ func (a *Api) ServerLogin(res http.ResponseWriter, req *http.Request) {
 		sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_NO_EXPECTED_PWD), http.StatusInternalServerError)
 		return
 	}
-	
+
 	// If the expected secret is the one given at the door then we can generate a token
 	if pw == expectedSecret {
 		//generate new token

--- a/user/api.go
+++ b/user/api.go
@@ -32,22 +32,27 @@ type (
 		logger           *log.Logger
 		mailchimpManager mailchimp.Manager
 	}
+	Secret struct {
+		Secret           string `json:"secret"`
+		Pass		      string `json:"pass"`
+	}
 	ApiConfig struct {
 		//used for services
-		ServerSecret         string `json:"serverSecret"`
-		LongTermKey          string `json:"longTermKey"`
-		LongTermDaysDuration int    `json:"longTermDaysDuration"`
+		secrets 			 	[]Secret `json:"secrets"`
+		ServerSecrets			map[string]string
+		LongTermKey          	string `json:"longTermKey"`
+		LongTermDaysDuration 	int    `json:"longTermDaysDuration"`
 		//so we can change the default lifetime of the token
 		//we use seconds, this also helps for testing as you can time it out easily
-		TokenDurationSecs int64 `json:"tokenDurationSecs"`
+		TokenDurationSecs 		int64 `json:"tokenDurationSecs"`
 		//used for pw
-		Salt string `json:"salt"`
+		Salt 					string `json:"salt"`
 		//used for token
-		Secret string `json:"apiSecret"`
+		Secret 					string `json:"apiSecret"`
 		//allows for the skipping of verification for testing
-		VerificationSecret string           `json:"verificationSecret"`
-		ClinicDemoUserID   string           `json:"clinicDemoUserId"`
-		Mailchimp          mailchimp.Config `json:"mailchimp"`
+		VerificationSecret 		string           `json:"verificationSecret"`
+		ClinicDemoUserID   		string           `json:"clinicDemoUserId"`
+		Mailchimp          		mailchimp.Config `json:"mailchimp"`
 	}
 	varsHandler func(http.ResponseWriter, *http.Request, map[string]string)
 )
@@ -85,6 +90,8 @@ const (
 	STATUS_UNAUTHORIZED          = "Not authorized for requested operation"
 	STATUS_NO_QUERY              = "A query must be specified"
 	STATUS_INVALID_ROLE          = "The role specified is invalid"
+	STATUS_OK        			 = "OK"
+	STATUS_NO_EXPECTED_PWD		 = "No expected password is found"
 )
 
 func InitApi(cfg ApiConfig, store Storage, metrics highwater.Client) *Api {
@@ -93,6 +100,13 @@ func InitApi(cfg ApiConfig, store Storage, metrics highwater.Client) *Api {
 	mailchimpManager, err := mailchimp.NewManager(logger, &http.Client{Timeout: 15 * time.Second}, &cfg.Mailchimp)
 	if err != nil {
 		logger.Println("WARNING: Mailchimp Manager not configured;", err)
+	}
+
+	// Server secrets retrieved from configuration are transformed into a hashtable for ease of access
+	// They are stored in a public property called ServerSecrets
+	cfg.ServerSecrets = make(map[string]string)
+	for _, sec := range cfg.secrets {
+		cfg.ServerSecrets[sec.Secret] = sec.Pass
 	}
 
 	return &Api{
@@ -155,6 +169,7 @@ func (a *Api) GetStatus(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 	res.WriteHeader(http.StatusOK)
+	res.Write([]byte(STATUS_OK))
 	return
 }
 
@@ -510,29 +525,57 @@ func (a *Api) Login(res http.ResponseWriter, req *http.Request) {
 // status: 500 STATUS_ERR_GENERATING_TOKEN
 func (a *Api) ServerLogin(res http.ResponseWriter, req *http.Request) {
 
+	// which server is knocking at the door and what password is it using to enter?
 	server, pw := req.Header.Get(TP_SERVER_NAME), req.Header.Get(TP_SERVER_SECRET)
+	// the expected secret is the secret that the requesting server is supposed to give to be delivered the token
+	expectedSecret := ""
 
+	// if server or password is not given we obviously have a problem
 	if server == "" || pw == "" {
 		a.logger.Println(http.StatusBadRequest, STATUS_MISSING_ID_PW)
 		sendModelAsResWithStatus(res, status.NewStatus(http.StatusBadRequest, STATUS_MISSING_ID_PW), http.StatusBadRequest)
 		return
 	}
-	if pw == a.ApiConfig.ServerSecret {
+
+	// At this stage both given password and server are passed and known
+
+	// What is the expected password for this specific requesting server?
+	expectedSecret = a.ApiConfig.ServerSecrets[server]
+
+	// Case specific to all Tidepool microservices that share the same secret
+	// This is done in order to maintain the current behaviour where Tidepool servers use the default password
+	// TODO: maintain a list of possible requesting micro-services?
+	if expectedSecret == "" {
+		expectedSecret = a.ApiConfig.ServerSecrets["default"]
+	}
+
+	// If no expected secret can be compared to, we have a problem and cannot continue
+	if expectedSecret == "" {
+		a.logger.Println(http.StatusInternalServerError, STATUS_NO_EXPECTED_PWD)
+		sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_NO_EXPECTED_PWD), http.StatusInternalServerError)
+		return
+	}
+	
+	// If the expected secret is the one given at the door then we can generate a token
+	if pw == expectedSecret {
 		//generate new token
 		if sessionToken, err := CreateSessionTokenAndSave(
 			&TokenData{DurationSecs: extractTokenDuration(req), UserId: server, IsServer: true},
 			TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret},
 			a.Store,
 		); err != nil {
+			// Error generating the token
 			a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())
 			sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN), http.StatusInternalServerError)
 			return
 		} else {
+			// Server is provided with the generated token
 			a.logMetricAsServer("serverlogin", sessionToken.ID, nil)
 			res.Header().Set(TP_SESSION_TOKEN, sessionToken.ID)
 			return
 		}
 	}
+	// If the password given at the door is wrong, we cannot generate the token
 	a.logger.Println(http.StatusUnauthorized, STATUS_PW_WRONG)
 	sendModelAsResWithStatus(res, status.NewStatus(http.StatusUnauthorized, STATUS_PW_WRONG), http.StatusUnauthorized)
 	return

--- a/user/apiClient.go
+++ b/user/apiClient.go
@@ -118,7 +118,8 @@ func (client *UserClient) TokenProvide() string {
 
 	request, _ := http.NewRequest("GET", "", nil)
 	request.Header.Set(TP_SERVER_NAME, "shoreline")
-	request.Header.Set(TP_SERVER_SECRET, client.userapi.ApiConfig.ServerSecret)
+	// Shoreline, as a Tidepool microservice, is using the default password
+	request.Header.Set(TP_SERVER_SECRET, client.userapi.ApiConfig.ServerSecrets["default"])
 	response := httptest.NewRecorder()
 
 	client.userapi.ServerLogin(response, request)

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -37,6 +37,7 @@ var (
 	FAKE_CONFIG    = ApiConfig{
 		secrets: []Secret{Secret{Secret: "default", Pass: "This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy"},
 			Secret{Secret: "product_website", Pass: "Not so secret"}},
+		Secret:             "This is a local API secret for everyone. BsscSHqSHiwrBMJsEGqbvXiuIUPAjQXU",
 		TokenDurationSecs:  TOKEN_DURATION,
 		LongTermKey:        "thelongtermkey",
 		Salt:               "a mineral substance composed primarily of sodium chloride",

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	THE_SECRET   = "shhh! don't tell"
+	THE_SECRET   = "This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy"
 	MAKE_IT_FAIL = true
 )
 
@@ -35,8 +35,8 @@ var (
 	NO_PARAMS      = map[string]string{}
 	TOKEN_DURATION = int64(3600)
 	FAKE_CONFIG    = ApiConfig{
-		ServerSecrets:       map[string]string{"default": "shhh! don't tell"},
-		Secret:             "shhh! don't tell *2",
+		secrets: []Secret{Secret{Secret: "default", Pass: "This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy"},
+			Secret{Secret: "product_website", Pass: "Not so secret"}},
 		TokenDurationSecs:  TOKEN_DURATION,
 		LongTermKey:        "thelongtermkey",
 		Salt:               "a mineral substance composed primarily of sodium chloride",

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -35,7 +35,7 @@ var (
 	NO_PARAMS      = map[string]string{}
 	TOKEN_DURATION = int64(3600)
 	FAKE_CONFIG    = ApiConfig{
-		ServerSecret:       "shhh! don't tell",
+		ServerSecrets:       map[string]string{"default": "shhh! don't tell"},
 		Secret:             "shhh! don't tell *2",
 		TokenDurationSecs:  TOKEN_DURATION,
 		LongTermKey:        "thelongtermkey",


### PR DESCRIPTION
Add the capability for shoreline to handle multiple secrets for multiple servers in order to serve more than Tidepool microservices servers. A requesting server that provides the expected password when requesting the API "ServerLogin" is being sent a token.
This will allow the capability to send one server a secret without compromising the other server secrets.