### PR TITLE
Fix soup document name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Shoreline is the module that manages logins and user accounts.
 
+## 1.0.1 - 2020-07-29
+- Fix Soup document name: remove dblp from tag
+
 ## 1.0.0 - 2020-07-28
 ### Changed
 - PT-1284 Integrate Tidepool master for shoreline

--- a/buildSoup.sh
+++ b/buildSoup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/bash -eu
 # Generate Soups
 
 DEPLOY_DOC=${DEPLOY_DOC:-docs/soup}
@@ -13,8 +13,9 @@ if [ -d ${DEPLOY_DOC} ]; then
   rm -rf ./${DEPLOY_DOC}
 fi
 
-echo "# SOUPs List for ${APP}@${TRAVIS_TAG}" > soup.md 
+VERSION=${TRAVIS_TAG/dblp./}
+echo "# SOUPs List for ${APP}@${VERSION}" > soup.md 
 
 go list -f '## {{printf "%s \n\t* description: \n\t* version: %s\n\t* webSite: https://%s\n\t* sources:" .Path .Version .Path}}' -m all >> soup.md && \
 	mkdir -p ./${DEPLOY_DOC}/${APP} && \
-	mv soup.md ./${DEPLOY_DOC}/${APP}/${APP}-${TRAVIS_TAG}-soup.md
+	mv soup.md ./${DEPLOY_DOC}/${APP}/${APP}-${VERSION}-soup.md


### PR DESCRIPTION
remove the `dblp.` from tag name so that the soup document is correctly named as shoreline-X.X.X-soup.md 