### PR TITLE
YLP-339 jwt token for Zendesk and other external services

### DIFF
--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -14,7 +14,8 @@
                 "TIDEPOOL_SHORELINE_ENV":"{\"gatekeeper\": {\"serviceSpec\": {\"type\": \"static\",\"hosts\": [\"http://localhost:9123\"]}},\"hakken\": {\"host\": \"fake-hakken\",\"skipHakken\": true}}",
                 "TIDEPOOL_SHORELINE_SERVICE":"{\"service\": {\"certFile\": \"config/cert.pem\",\"host\": \"localhost:9107\",\"keyFile\": \"config/key.pem\",\"protocol\": \"http\",\"service\": \"shoreline\"},\"user\": {\"longTermDaysDuration\": 30,\"tokenDurationSecs\": 2592000, \"secrets\": [{\"secret\": \"default\", \"pass\": \"${SERVER_SECRET}\"},{\"secret\": \"authent_api\", \"pass\": \"${AUTHENT_API_SECRET}\"}],\"maxFailedLogin\":5,\"delayBeforeNextLoginAttempt\":10,\"maxConcurrentLogin\":100,\"blockParallelLogin\": true,\"mailchimp\": {\"url\": \"${MAILCHIMP_URL}\",\"apiKey\": \"${MAILCHIMP_API_KEY}\",\"personalLists\": [],\"clinicLists\" : []}}}",
                 "API_SECRET":"${SHORELINE_API_SECRET}"
-                "VERIFICATION_SECRET": "${SHORELINE_VERIFICATION_SECRET}",
+                "ZENDESK_SECRET":"yourSharedSecret",
+                "VERIFICATION_SECRET": "+skip",
                 "SALT":"${SHORELINE_SALT}",
                 "LONG_TERM_KEY":"${SHORELINE_LONG_TERM_KEY}"
                 "DEMO_CLINIC_USER_ID":""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Shoreline is the module that manages logins and user accounts.
 
+## UNRELEASED
+- YLP-339 New route to provide JWT tokens for external services
+
 ## 1.1.2 - 2020-10-29
 ### Engineering
 - YLP-243 Review openapi generation so we can serve it through a website

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/codegangsta/cli v1.20.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.3
 	github.com/prometheus/client_golang v1.4.1
 	github.com/swaggo/swag v1.6.9

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -238,6 +240,7 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.mongodb.org/mongo-driver v1.4.0 h1:C8rFn1VF4GVEM/rG+dSoMmlm2pyQ9cs2/oRtUATejRU=
 go.mongodb.org/mongo-driver v1.4.0/go.mod h1:llVBH2pkj9HywK0Dtdt6lDikOjFLbceHVu/Rc0iMKLs=
+go.mongodb.org/mongo-driver v1.4.4 h1:bsPHfODES+/yx2PCWzUYMH8xj6PVniPI8DQrsJuSXSs=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=

--- a/shoreline.go
+++ b/shoreline.go
@@ -86,10 +86,16 @@ func main() {
 	if found {
 		config.User.ServerSecrets["default"] = serverSecret
 	}
-
+	// extract the list of token secrets
+	config.User.TokenSecrets = make(map[string]string)
+	zdkSecret, found := os.LookupEnv("ZENDESK_SECRET")
+	if found {
+		config.User.TokenSecrets["zendesk"] = zdkSecret
+	}
 	userSecret, found := os.LookupEnv("API_SECRET")
 	if found {
 		config.User.Secret = userSecret
+		config.User.TokenSecrets["default"] = userSecret
 	}
 
 	mailchimpAPIKey, found := os.LookupEnv("MAILCHIMP_APIKEY")

--- a/user/api.go
+++ b/user/api.go
@@ -169,7 +169,8 @@ type (
 		//used for pw
 		Salt string `json:"salt"`
 		//used for token
-		Secret string `json:"apiSecret"`
+		Secret       string `json:"apiSecret"`
+		TokenSecrets map[string]string
 		// Maximum number of consecutive failed login before a delay is set
 		MaxFailedLogin int `json:"maxFailedLogin"`
 		// Delay in minutes the user must wait 10min before attempting a new login if the number of
@@ -199,9 +200,10 @@ const (
 	//api logging prefix
 	USER_API_PREFIX = "api/user "
 
-	TP_SERVER_NAME   = "x-tidepool-server-name"
-	TP_SERVER_SECRET = "x-tidepool-server-secret"
-	TP_SESSION_TOKEN = "x-tidepool-session-token"
+	TP_SERVER_NAME    = "x-tidepool-server-name"
+	TP_SERVER_SECRET  = "x-tidepool-server-secret"
+	TP_SESSION_TOKEN  = "x-tidepool-session-token"
+	EXT_SESSION_TOKEN = "x-external-session-token"
 	// TP_TRACE_SESSION Session trace: uuid v4
 	TP_TRACE_SESSION = "x-tidepool-trace-session"
 
@@ -292,6 +294,8 @@ func (a *Api) SetHandlers(prefix string, rtr *mux.Router) {
 	rtr.HandleFunc("/serverlogin", a.ServerLogin).Methods("POST")
 
 	rtr.Handle("/token/{token}", varsHandler(a.ServerCheckToken)).Methods("GET")
+
+	rtr.Handle("/sso/{service}", varsHandler(a.Get3rdPartyToken)).Methods("POST")
 
 	rtr.HandleFunc("/logout", a.Logout).Methods("POST")
 
@@ -771,7 +775,7 @@ func (a *Api) Login(res http.ResponseWriter, req *http.Request) {
 		a.sendError(res, http.StatusForbidden, STATUS_NOT_VERIFIED)
 
 	} else {
-		tokenData := &TokenData{DurationSecs: extractTokenDuration(req), UserId: result.Id}
+		tokenData := &TokenData{DurationSecs: extractTokenDuration(req), UserId: result.Id, Email: result.Username, Name: result.Username, IsClinic: result.IsClinic()}
 		tokenConfig := TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
 		if sessionToken, err := CreateSessionTokenAndSave(tokenData, tokenConfig, a.Store); err != nil {
 			a.sendError(res, http.StatusInternalServerError, STATUS_ERR_UPDATING_TOKEN, err)
@@ -954,7 +958,6 @@ func (a *Api) ServerCheckToken(res http.ResponseWriter, req *http.Request, vars 
 			sendModelAsResWithStatus(res, status.NewStatus(http.StatusUnauthorized, STATUS_NO_TOKEN), http.StatusUnauthorized)
 			return
 		}
-
 		sendModelAsRes(res, td)
 		return
 	}
@@ -996,6 +999,60 @@ func (a *Api) AnonymousIdHashPair(res http.ResponseWriter, req *http.Request) {
 	idHashPair := NewAnonIdHashPair([]string{a.ApiConfig.Salt}, req.URL.Query())
 	sendModelAsRes(res, idHashPair)
 	return
+}
+
+// @Summary Generate a 3rd party JWT
+// @Description Generate a token to authenticate the user to a 3rd party service
+// @ID shoreline-user-api-getToken
+// @Param service path string true ""rd party service name"
+// @Security TidepoolAuth
+// @Success 200 {object} status.Status
+// @Failure 500 {object} status.Status "message returned:\"Error generating the token" "
+// @Failure 401 {object} status.Status "message returned:\"Not authorized for requested operation\" "
+// @Failure 400 {object} status.Status "message returned:\"Unknown query parameter\" or \"Error generating the token\" "
+// @Router /sso/{service} [post]
+func (a *Api) Get3rdPartyToken(res http.ResponseWriter, req *http.Request, vars map[string]string) {
+
+	secret := ""
+	service := vars["service"]
+	if service == "" {
+		sendModelAsResWithStatus(res, status.NewStatus(http.StatusBadRequest, STATUS_PARAMETER_UNKNOWN), http.StatusBadRequest)
+		return
+	} else {
+		secret = a.ApiConfig.TokenSecrets[service]
+	}
+
+	if secret == "" {
+		// the secret is not defined for this service
+		a.logger.Println(http.StatusBadRequest, "the service does not exist")
+		sendModelAsResWithStatus(res, status.NewStatus(http.StatusBadRequest, STATUS_ERR_GENERATING_TOKEN), http.StatusBadRequest)
+		return
+	}
+
+	// Should we also support authentication with login/pwd?
+	td, err := a.authenticateSessionToken(req.Header.Get(TP_SESSION_TOKEN))
+
+	if err != nil {
+		a.logger.Println(http.StatusUnauthorized, err.Error())
+		res.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	td.Audience = service
+	//refresh
+	if sessionToken, err := CreateSessionTokenAndSave(
+		td,
+		TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: secret},
+		a.Store,
+	); err != nil {
+		a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())
+		sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN), http.StatusInternalServerError)
+		return
+	} else {
+		a.logAudit(req, td, "GenerateExternalToken")
+		res.Header().Set(EXT_SESSION_TOKEN, sessionToken.ID)
+		sendModelAsRes(res, td)
+		return
+	}
 }
 
 func (a *Api) sendError(res http.ResponseWriter, statusCode int, reason string, extras ...interface{}) {

--- a/user/api.go
+++ b/user/api.go
@@ -1004,7 +1004,7 @@ func (a *Api) AnonymousIdHashPair(res http.ResponseWriter, req *http.Request) {
 // @Summary Generate a 3rd party JWT
 // @Description Generate a token to authenticate the user to a 3rd party service
 // @ID shoreline-user-api-getToken
-// @Param service path string true ""rd party service name"
+// @Param service path string true "3rd party service name"
 // @Security TidepoolAuth
 // @Success 200 {object} status.Status
 // @Failure 500 {object} status.Status "message returned:\"Error generating the token" "

--- a/user/api.go
+++ b/user/api.go
@@ -295,7 +295,7 @@ func (a *Api) SetHandlers(prefix string, rtr *mux.Router) {
 
 	rtr.Handle("/token/{token}", varsHandler(a.ServerCheckToken)).Methods("GET")
 
-	rtr.Handle("/sso/{service}", varsHandler(a.Get3rdPartyToken)).Methods("POST")
+	rtr.Handle("/ext-token/{service}", varsHandler(a.Get3rdPartyToken)).Methods("POST")
 
 	rtr.HandleFunc("/logout", a.Logout).Methods("POST")
 
@@ -1010,7 +1010,7 @@ func (a *Api) AnonymousIdHashPair(res http.ResponseWriter, req *http.Request) {
 // @Failure 500 {object} status.Status "message returned:\"Error generating the token" "
 // @Failure 401 {object} status.Status "message returned:\"Not authorized for requested operation\" "
 // @Failure 400 {object} status.Status "message returned:\"Unknown query parameter\" or \"Error generating the token\" "
-// @Router /sso/{service} [post]
+// @Router /ext-token/{service} [post]
 func (a *Api) Get3rdPartyToken(res http.ResponseWriter, req *http.Request, vars map[string]string) {
 
 	secret := ""
@@ -1029,7 +1029,6 @@ func (a *Api) Get3rdPartyToken(res http.ResponseWriter, req *http.Request, vars 
 		return
 	}
 
-	// Should we also support authentication with login/pwd?
 	td, err := a.authenticateSessionToken(req.Header.Get(TP_SESSION_TOKEN))
 
 	if err != nil {
@@ -1039,10 +1038,9 @@ func (a *Api) Get3rdPartyToken(res http.ResponseWriter, req *http.Request, vars 
 	}
 	td.Audience = service
 	//refresh
-	if sessionToken, err := CreateSessionTokenAndSave(
+	if sessionToken, err := CreateSessionToken(
 		td,
 		TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: secret},
-		a.Store,
 	); err != nil {
 		a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())
 		sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN), http.StatusInternalServerError)

--- a/user/token.go
+++ b/user/token.go
@@ -76,9 +76,10 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 	// Add claims specific to our 3rd party services
 	if strings.ToUpper(data.Audience) == "ZENDESK" {
 		if data.IsClinic {
-			claims["organization"] = "clinic"
+			claims["organization"] = "Psad"
 		} else {
-			claims["organization"] = "patient"
+			claims["organization"] = "Patient"
+			claims["tags"] = "patient"
 		}
 		claims["aud"] = "zendesk"
 	}

--- a/user/token.go
+++ b/user/token.go
@@ -151,8 +151,15 @@ func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
 		durationSecs = int64(claims["dur"].(float64))
 	}
 	userId := claims["usr"].(string)
-	email := claims["email"].(string)
-	name := claims["name"].(string)
+
+	email, ok := claims["email"].(string)
+	if !ok {
+		email = ""
+	}
+	name, ok := claims["name"].(string)
+	if !ok {
+		name = email
+	}
 
 	return &TokenData{
 		IsServer:     isServer,


### PR DESCRIPTION
The goal of this change is to add a new route "/sso/{service}" which generates a new token signed with a key dedicated to a 3rd party service. This way we can use shoreline to authenticate users to other services without sharing the internal secret. 
This new route is only available for authenticated users.