### PR TITLE
YLP-505 Add new roles and send them within the token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 Shoreline is the module that manages logins and user accounts.
 
-## Unreleased
+## 1.3.0
+### Added
+- YLP-505 Add patient, hcp and caregiver roles to our user token (used for teams permissions)
+
 ### Changed
 - YLP-446 Upgrade go-common to 0.6.2 version
 - YLP-475 Remove "Custodian" authorization in shoreline

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHM
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.mongodb.org/mongo-driver v1.4.0 h1:C8rFn1VF4GVEM/rG+dSoMmlm2pyQ9cs2/oRtUATejRU=
 go.mongodb.org/mongo-driver v1.4.0/go.mod h1:llVBH2pkj9HywK0Dtdt6lDikOjFLbceHVu/Rc0iMKLs=
+go.mongodb.org/mongo-driver v1.4.5 h1:TLtO+iD8krabXxvY1F1qpBOHgOxhLWR7XsT7kQeRmMY=
+go.mongodb.org/mongo-driver v1.4.6 h1:rh7GdYmDrb8AQSkF8yteAus8qYOgOASWDOv1BWqBXkU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=

--- a/shoreline.go
+++ b/shoreline.go
@@ -126,10 +126,6 @@ func main() {
 		}
 	}
 
-	clinicDemoUserID, found := os.LookupEnv("DEMO_CLINIC_USER_ID")
-	if found {
-		config.User.ClinicDemoUserID = clinicDemoUserID
-	}
 	config.User.Marketo.ID, _ = os.LookupEnv("MARKETO_ID")
 
 	config.User.Marketo.URL, _ = os.LookupEnv("MARKETO_URL")

--- a/user/api.go
+++ b/user/api.go
@@ -406,7 +406,7 @@ func (a *Api) CreateUser(res http.ResponseWriter, req *http.Request) {
 		a.sendError(res, http.StatusInternalServerError, STATUS_ERR_CREATING_USR, err)
 
 	} else {
-		tokenData := TokenData{DurationSecs: extractTokenDuration(req), UserId: newUser.Id, IsServer: false}
+		tokenData := TokenData{DurationSecs: extractTokenDuration(req), UserId: newUser.Id, IsServer: false, Role: "unverified"}
 		tokenConfig := TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
 		if sessionToken, err := CreateSessionTokenAndSave(req.Context(), &tokenData, tokenConfig, a.Store); err != nil {
 			a.sendError(res, http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err)
@@ -1096,7 +1096,7 @@ func (a *Api) authenticateSessionToken(ctx context.Context, sessionToken string)
 func (a *Api) isAuthorized(tokenData *TokenData, userID string) bool {
 	if tokenData.IsServer {
 		return true
-	} 
+	}
 	if tokenData.UserId == userID {
 		return true
 	}

--- a/user/api.go
+++ b/user/api.go
@@ -697,7 +697,7 @@ func (a *Api) Login(res http.ResponseWriter, req *http.Request) {
 		if result.Roles != nil && len(result.Roles) > 0 {
 			role = result.Roles[0]
 		}
-		tokenData := &TokenData{DurationSecs: extractTokenDuration(req), UserId: result.Id, Email: result.Username, Name: result.Username, Role: role, IsClinic: result.IsClinic()}
+		tokenData := &TokenData{DurationSecs: extractTokenDuration(req), UserId: result.Id, Email: result.Username, Name: result.Username, Role: role}
 		tokenConfig := TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
 		if sessionToken, err := CreateSessionTokenAndSave(req.Context(), tokenData, tokenConfig, a.Store); err != nil {
 			a.sendError(res, http.StatusInternalServerError, STATUS_ERR_UPDATING_TOKEN, err)

--- a/user/api.go
+++ b/user/api.go
@@ -180,7 +180,6 @@ type (
 		BlockParallelLogin bool `json:blockParallelLogin`
 		//allows for the skipping of verification for testing
 		VerificationSecret string           `json:"verificationSecret"`
-		ClinicDemoUserID   string           `json:"clinicDemoUserId"`
 		Mailchimp          mailchimp.Config `json:"mailchimp"`
 		// to create type/file
 		Marketo marketo.Config `json:"marketo"`

--- a/user/api.go
+++ b/user/api.go
@@ -693,7 +693,12 @@ func (a *Api) Login(res http.ResponseWriter, req *http.Request) {
 		a.sendError(res, http.StatusForbidden, STATUS_NOT_VERIFIED)
 
 	} else {
-		tokenData := &TokenData{DurationSecs: extractTokenDuration(req), UserId: result.Id, Email: result.Username, Name: result.Username, IsClinic: result.IsClinic()}
+		// TODO: replace this workaround, there should be only one role when the data is cleaned up
+		role := "patient"
+		if result.Roles != nil && len(result.Roles) > 0 {
+			role = result.Roles[0]
+		}
+		tokenData := &TokenData{DurationSecs: extractTokenDuration(req), UserId: result.Id, Email: result.Username, Name: result.Username, Role: role, IsClinic: result.IsClinic()}
 		tokenConfig := TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
 		if sessionToken, err := CreateSessionTokenAndSave(req.Context(), tokenData, tokenConfig, a.Store); err != nil {
 			a.sendError(res, http.StatusInternalServerError, STATUS_ERR_UPDATING_TOKEN, err)

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -63,7 +63,6 @@ var (
 		DelayBeforeNextLoginAttempt: 10,
 		MaxConcurrentLogin:          100,
 		VerificationSecret:          "",
-		ClinicDemoUserID:            "00000000",
 		Marketo: marketo.Config{
 			ID:          "1234",
 			Secret:      "shhh! don't tell *3",

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -67,7 +67,7 @@ var (
 			ID:          "1234",
 			Secret:      "shhh! don't tell *3",
 			URL:         "https:xxx-xxx-xxx.mktorest.com",
-			ClinicRole:  "clinic",
+			ClinicRole:  "hcp",
 			PatientRole: "user",
 			Timeout:     10,
 		},
@@ -101,8 +101,8 @@ var (
 	mockStoreFails = NewMockStoreClient(FAKE_CONFIG.Salt, false, MAKE_IT_FAIL)
 	shorelineFails = InitAPITest(FAKE_CONFIG, logger, mockStoreFails, mockMarketoManager)
 
-	responsableStore      = NewResponsableMockStoreClient()
-	responsableShoreline  = InitShoreline(FAKE_CONFIG, responsableStore)
+	responsableStore     = NewResponsableMockStoreClient()
+	responsableShoreline = InitShoreline(FAKE_CONFIG, responsableStore)
 )
 
 func InitShoreline(config ApiConfig, store Storage) *Api {
@@ -357,7 +357,7 @@ func TestGetStatus_StatusInternalServerError(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////////////
 
 func Test_GetUsers_Error_MissingSessionToken(t *testing.T) {
-	response := T_PerformRequest(t, "GET", "/users?role=clinic")
+	response := T_PerformRequest(t, "GET", "/users?role=hcp")
 	T_ExpectErrorResponse(t, response, 401, "Not authorized for requested operation")
 }
 
@@ -368,7 +368,7 @@ func Test_GetUsers_Error_TokenError(t *testing.T) {
 
 	headers := http.Header{}
 	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
-	response := T_PerformRequestHeaders(t, "GET", "/users?role=clinic", headers)
+	response := T_PerformRequestHeaders(t, "GET", "/users?role=hcp", headers)
 	T_ExpectErrorResponse(t, response, 401, "Not authorized for requested operation")
 }
 
@@ -379,7 +379,7 @@ func Test_GetUsers_Error_NotServerToken(t *testing.T) {
 
 	headers := http.Header{}
 	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
-	response := T_PerformRequestHeaders(t, "GET", "/users?role=clinic", headers)
+	response := T_PerformRequestHeaders(t, "GET", "/users?role=hcp", headers)
 	T_ExpectErrorResponse(t, response, 401, "Not authorized for requested operation")
 }
 
@@ -478,7 +478,7 @@ func Test_GetUsers_Error_FindUsersByRoleError(t *testing.T) {
 
 	headers := http.Header{}
 	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
-	response := T_PerformRequestHeaders(t, "GET", "/users?role=clinic", headers)
+	response := T_PerformRequestHeaders(t, "GET", "/users?role=hcp", headers)
 	T_ExpectErrorResponse(t, response, 500, "Error finding user")
 }
 
@@ -490,7 +490,7 @@ func Test_GetUsers_Error_FindUsersByRoleSuccess(t *testing.T) {
 
 	headers := http.Header{}
 	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
-	response := T_PerformRequestHeaders(t, "GET", "/users?role=clinic", headers)
+	response := T_PerformRequestHeaders(t, "GET", "/users?role=hcp", headers)
 	successResponse := T_ExpectSuccessResponseWithJSONArray(t, response, 200)
 	T_ExpectEqualsArray(t, successResponse, []interface{}{map[string]interface{}{"userid": "0000000000", "passwordExists": false}, map[string]interface{}{"userid": "1111111111", "passwordExists": false}})
 }
@@ -562,11 +562,11 @@ func Test_CreateUser_Success(t *testing.T) {
 	responsableStore.AddTokenResponses = []error{nil}
 	defer T_ExpectResponsablesEmpty(t)
 
-	body := "{\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"]}"
+	body := "{\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"], \"password\": \"12345678\", \"roles\": [\"hcp\"]}"
 	response := T_PerformRequestBody(t, "POST", "/user", body)
 	successResponse := T_ExpectSuccessResponseWithJSONMap(t, response, 201)
 	T_ExpectElementMatch(t, successResponse, "userid", `\A[0-9a-f]{10}\z`, true)
-	T_ExpectEqualsMap(t, successResponse, map[string]interface{}{"emailVerified": false, "emails": []interface{}{"a@z.co"}, "username": "a@z.co", "roles": []interface{}{"clinic"}})
+	T_ExpectEqualsMap(t, successResponse, map[string]interface{}{"emailVerified": false, "emails": []interface{}{"a@z.co"}, "username": "a@z.co", "roles": []interface{}{"hcp"}})
 	if response.Header().Get(TP_SESSION_TOKEN) == "" {
 		t.Fatalf("Missing expected %s header", TP_SESSION_TOKEN)
 	}
@@ -649,7 +649,7 @@ func Test_UpdateUser_Error_UnauthorizedRoles_User(t *testing.T) {
 	responsableStore.FindUserResponses = []FindUserResponse{{&User{Id: "1111111111"}, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
-	body := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"], \"roles\": [\"clinic\"]}}"
+	body := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"], \"roles\": [\"hcp\"]}}"
 	headers := http.Header{}
 	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
 	response := T_PerformRequestBodyHeaders(t, "PUT", "/user/1111111111", body, headers)
@@ -728,13 +728,13 @@ func Test_UpdateUser_Success_Server_WithoutPassword(t *testing.T) {
 	responsableStore.UpsertUserResponses = []error{nil}
 	defer T_ExpectResponsablesEmpty(t)
 
-	body := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"], \"roles\": [\"clinic\"], \"emailVerified\": true, \"termsAccepted\": \"2016-01-01T01:23:45-08:00\"}}"
+	body := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"], \"roles\": [\"hcp\"], \"emailVerified\": true, \"termsAccepted\": \"2016-01-01T01:23:45-08:00\"}}"
 	headers := http.Header{}
 	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
 	response := T_PerformRequestBodyHeaders(t, "PUT", "/user/1111111111", body, headers)
 	successResponse := T_ExpectSuccessResponseWithJSONMap(t, response, 200)
 	T_ExpectElementMatch(t, successResponse, "userid", `\A[0-9a-f]{10}\z`, true)
-	T_ExpectEqualsMap(t, successResponse, map[string]interface{}{"emailVerified": true, "emails": []interface{}{"a@z.co"}, "username": "a@z.co", "roles": []interface{}{"clinic"}, "termsAccepted": "2016-01-01T01:23:45-08:00", "passwordExists": false})
+	T_ExpectEqualsMap(t, successResponse, map[string]interface{}{"emailVerified": true, "emails": []interface{}{"a@z.co"}, "username": "a@z.co", "roles": []interface{}{"hcp"}, "termsAccepted": "2016-01-01T01:23:45-08:00", "passwordExists": false})
 }
 
 func Test_UpdateUser_Success_Server_WithPassword(t *testing.T) {
@@ -745,13 +745,13 @@ func Test_UpdateUser_Success_Server_WithPassword(t *testing.T) {
 	responsableStore.UpsertUserResponses = []error{nil}
 	defer T_ExpectResponsablesEmpty(t)
 
-	body := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"], \"password\": \"newpassword\", \"roles\": [\"clinic\"], \"emailVerified\": true, \"termsAccepted\": \"2016-01-01T01:23:45-08:00\"}}"
+	body := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"], \"password\": \"newpassword\", \"roles\": [\"hcp\"], \"emailVerified\": true, \"termsAccepted\": \"2016-01-01T01:23:45-08:00\"}}"
 	headers := http.Header{}
 	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
 	response := T_PerformRequestBodyHeaders(t, "PUT", "/user/1111111111", body, headers)
 	successResponse := T_ExpectSuccessResponseWithJSONMap(t, response, 200)
 	T_ExpectElementMatch(t, successResponse, "userid", `\A[0-9a-f]{10}\z`, true)
-	T_ExpectEqualsMap(t, successResponse, map[string]interface{}{"emailVerified": true, "emails": []interface{}{"a@z.co"}, "username": "a@z.co", "roles": []interface{}{"clinic"}, "termsAccepted": "2016-01-01T01:23:45-08:00", "passwordExists": true})
+	T_ExpectEqualsMap(t, successResponse, map[string]interface{}{"emailVerified": true, "emails": []interface{}{"a@z.co"}, "username": "a@z.co", "roles": []interface{}{"hcp"}, "termsAccepted": "2016-01-01T01:23:45-08:00", "passwordExists": true})
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/user/token.go
+++ b/user/token.go
@@ -30,6 +30,7 @@ type (
 		Email        string `json:"email"`
 		Name         string `json:"name"`
 		IsClinic     bool   `json:"isclinic"`
+		Role         string `json:"role"`
 		DurationSecs int64  `json:"-"`
 		Audience     string `json:"audience"`
 	}
@@ -83,6 +84,8 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 			claims["tags"] = "patient"
 		}
 		claims["aud"] = "zendesk"
+	} else {
+		claims["role"] = data.Role
 	}
 	claims["usr"] = data.UserId
 	if data.Name != "" {
@@ -162,6 +165,10 @@ func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
 	if !ok {
 		name = email
 	}
+	role, ok := claims["role"].(string)
+	if !ok {
+		role = ""
+	}
 
 	return &TokenData{
 		IsServer:     isServer,
@@ -169,6 +176,7 @@ func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
 		UserId:       userId,
 		Email:        email,
 		Name:         name,
+		Role:         role,
 	}, nil
 }
 

--- a/user/token.go
+++ b/user/token.go
@@ -77,14 +77,17 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 	// Add claims specific to our 3rd party services
 	if strings.ToUpper(data.Audience) == "ZENDESK" {
 		if data.Role == "patient" {
-			claims["organization"] = "Patient"
-			claims["tags"] = "Patient"
+			claims["organization"] = "patient"
+			claims["tags"] = "patient"
 		}
 		if data.Role == "hcp" {
-			claims["organization"] = "Psad"
-			claims["tags"] = "Psad"
+			claims["organization"] = "professional"
+			claims["tags"] = "professional"
 		}
-		// what about caregivers?
+		if data.Role == "caregiver" {
+			claims["organization"] = "patient"
+			claims["tags"] = "patient"
+		}
 		claims["aud"] = "zendesk"
 	} else {
 		claims["role"] = data.Role

--- a/user/token.go
+++ b/user/token.go
@@ -29,7 +29,6 @@ type (
 		UserId       string `json:"userid"`
 		Email        string `json:"email"`
 		Name         string `json:"name"`
-		IsClinic     bool   `json:"isclinic"`
 		Role         string `json:"role"`
 		DurationSecs int64  `json:"-"`
 		Audience     string `json:"audience"`
@@ -77,12 +76,15 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 	}
 	// Add claims specific to our 3rd party services
 	if strings.ToUpper(data.Audience) == "ZENDESK" {
-		if data.IsClinic {
-			claims["organization"] = "Psad"
-		} else {
+		if data.Role == "patient" {
 			claims["organization"] = "Patient"
 			claims["tags"] = "patient"
 		}
+		if data.Role == "hcp" {
+			claims["organization"] = "Psad"
+			claims["tags"] = "Psad"
+		}
+		// what about caregivers?
 		claims["aud"] = "zendesk"
 	} else {
 		claims["role"] = data.Role

--- a/user/token.go
+++ b/user/token.go
@@ -78,7 +78,7 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 	if strings.ToUpper(data.Audience) == "ZENDESK" {
 		if data.Role == "patient" {
 			claims["organization"] = "Patient"
-			claims["tags"] = "patient"
+			claims["tags"] = "Patient"
 		}
 		if data.Role == "hcp" {
 			claims["organization"] = "Psad"

--- a/user/token_test.go
+++ b/user/token_test.go
@@ -122,10 +122,10 @@ func Test_GenerateSessionToken_Zendesk_Claims_Patient(t *testing.T) {
 	claims := jwtToken.Claims.(jwt.MapClaims)
 
 	// check zendesk claims
-	if claims["organization"] != "Patient" {
+	if claims["organization"] != "patient" {
 		t.Fatalf("the organization should have been set to 'Patient'")
 	}
-	if claims["tags"] != "Patient" {
+	if claims["tags"] != "patient" {
 		t.Fatalf("the tags should have been set to 'Patient'")
 	}
 	if claims["aud"] != "zendesk" {
@@ -133,7 +133,39 @@ func Test_GenerateSessionToken_Zendesk_Claims_Patient(t *testing.T) {
 	}
 }
 
-func Test_GenerateSessionToken_Zendesk_Claims_Psad(t *testing.T) {
+func Test_GenerateSessionToken_Zendesk_Claims_Caregiver(t *testing.T) {
+
+	testData := tokenTestData{
+		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Audience: "zendesk", Role: "caregiver"},
+		config: tokenConfig,
+	}
+
+	token, _ := CreateSessionToken(testData.data, testData.config)
+
+	if token.ID == "" || token.Time == 0 {
+		t.Fatalf("should generate a session token")
+	}
+
+	jwtToken, err := jwt.Parse(token.ID, func(t *jwt.Token) (interface{}, error) { return []byte(testData.config.Secret), nil })
+	if err != nil || !jwtToken.Valid {
+		t.Fatalf("should decode and validate the token")
+	}
+
+	claims := jwtToken.Claims.(jwt.MapClaims)
+
+	// check zendesk claims
+	if claims["organization"] != "patient" {
+		t.Fatalf("the organization should have been set to 'Patient'")
+	}
+	if claims["tags"] != "patient" {
+		t.Fatalf("the tags should have been set to 'Patient'")
+	}
+	if claims["aud"] != "zendesk" {
+		t.Fatalf("the audience should have been set to 'zendesk'")
+	}
+}
+
+func Test_GenerateSessionToken_Zendesk_Claims_Pro(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Audience: "zendesk", Role: "hcp"},
@@ -154,11 +186,11 @@ func Test_GenerateSessionToken_Zendesk_Claims_Psad(t *testing.T) {
 	claims := jwtToken.Claims.(jwt.MapClaims)
 
 	// check zendesk claims
-	if claims["organization"] != "Psad" {
-		t.Fatalf("the organization should have been set to 'Psad'")
+	if claims["organization"] != "professional" {
+		t.Fatalf("the organization should have been set to 'professional'")
 	}
-	if claims["tags"] != "Psad" {
-		t.Fatalf("the tags should have been set to 'Psad'")
+	if claims["tags"] != "professional" {
+		t.Fatalf("the tags should have been set to 'professional'")
 	}
 	if claims["aud"] != "zendesk" {
 		t.Fatalf("the audience should have been set to 'zendesk'")

--- a/user/token_test.go
+++ b/user/token_test.go
@@ -101,10 +101,10 @@ func Test_GenerateSessionToken_DurationSecsTrumpConfig(t *testing.T) {
 
 }
 
-func Test_GenerateSessionToken_Zendesk_Claims(t *testing.T) {
+func Test_GenerateSessionToken_Zendesk_Claims_Patient(t *testing.T) {
 
 	testData := tokenTestData{
-		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Audience: "zendesk"},
+		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Audience: "zendesk", Role: "patient"},
 		config: tokenConfig,
 	}
 
@@ -125,15 +125,18 @@ func Test_GenerateSessionToken_Zendesk_Claims(t *testing.T) {
 	if claims["organization"] != "Patient" {
 		t.Fatalf("the organization should have been set to 'Patient'")
 	}
+	if claims["tags"] != "Patient" {
+		t.Fatalf("the tags should have been set to 'Patient'")
+	}
 	if claims["aud"] != "zendesk" {
 		t.Fatalf("the audience should have been set to 'zendesk'")
 	}
 }
 
-func Test_GenerateSessionToken_With_UserDetails(t *testing.T) {
+func Test_GenerateSessionToken_Zendesk_Claims_Psad(t *testing.T) {
 
 	testData := tokenTestData{
-		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Email: "user@test.com", Name: "John Doe"},
+		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Audience: "zendesk", Role: "hcp"},
 		config: tokenConfig,
 	}
 
@@ -151,11 +154,45 @@ func Test_GenerateSessionToken_With_UserDetails(t *testing.T) {
 	claims := jwtToken.Claims.(jwt.MapClaims)
 
 	// check zendesk claims
+	if claims["organization"] != "Psad" {
+		t.Fatalf("the organization should have been set to 'Psad'")
+	}
+	if claims["tags"] != "Psad" {
+		t.Fatalf("the tags should have been set to 'Psad'")
+	}
+	if claims["aud"] != "zendesk" {
+		t.Fatalf("the audience should have been set to 'zendesk'")
+	}
+}
+
+func Test_GenerateSessionToken_With_UserDetails(t *testing.T) {
+
+	testData := tokenTestData{
+		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Email: "user@test.com", Name: "John Doe", Role: "hcp"},
+		config: tokenConfig,
+	}
+
+	token, _ := CreateSessionToken(testData.data, testData.config)
+
+	if token.ID == "" || token.Time == 0 {
+		t.Fatalf("should generate a session token")
+	}
+
+	jwtToken, err := jwt.Parse(token.ID, func(t *jwt.Token) (interface{}, error) { return []byte(testData.config.Secret), nil })
+	if err != nil || !jwtToken.Valid {
+		t.Fatalf("should decode and validate the token")
+	}
+
+	claims := jwtToken.Claims.(jwt.MapClaims)
+
 	if claims["email"] != testData.data.Email {
 		t.Fatalf("the email should have been set")
 	}
 	if claims["name"] != testData.data.Name {
-		t.Fatalf("the ame should have been set")
+		t.Fatalf("the name should have been set")
+	}
+	if claims["role"] != testData.data.Role {
+		t.Fatalf("the role should have been set")
 	}
 }
 
@@ -199,7 +236,7 @@ func Test_GenerateSessionToken_Server(t *testing.T) {
 func Test_UnpackedData(t *testing.T) {
 
 	testData := tokenTestData{
-		data:   &TokenData{UserId: "111", IsServer: true, DurationSecs: 0},
+		data:   &TokenData{UserId: "111", IsServer: true, DurationSecs: 0, Email: "user@test.com", Name: "John Doe", Role: "hcp"},
 		config: tokenConfig,
 	}
 
@@ -220,6 +257,18 @@ func Test_UnpackedData(t *testing.T) {
 
 	if data.UserId != testData.data.UserId {
 		t.Fatal("the user should have been what was given")
+	}
+
+	if data.Email != testData.data.Email {
+		t.Fatal("the Email should have been what was given")
+	}
+
+	if data.Name != testData.data.Name {
+		t.Fatal("the Name should have been what was given")
+	}
+
+	if data.Role != testData.data.Role {
+		t.Fatal("the Role should have been what was given")
 	}
 
 }

--- a/user/user.go
+++ b/user/user.go
@@ -148,14 +148,13 @@ func IsValidPassword(password string) bool {
 }
 
 func IsValidRole(role string) bool {
-	// With the current behaviour, patients are created without role
 	switch role {
 	case "caregiver":
 		return true
 	case "hcp":
 		return true
-	// case "patient":
-	// 	return true
+	case "patient":
+		return true
 	default:
 		return false
 	}

--- a/user/user.go
+++ b/user/user.go
@@ -148,9 +148,14 @@ func IsValidPassword(password string) bool {
 }
 
 func IsValidRole(role string) bool {
+	// With the current behaviour, patients are created without role
 	switch role {
-	case "clinic":
+	case "caregiver":
 		return true
+	case "hcp":
+		return true
+	// case "patient":
+	// 	return true
 	default:
 		return false
 	}
@@ -228,11 +233,15 @@ func (details *NewUserDetails) Validate() error {
 	}
 
 	if details.Roles != nil {
+		// Should we reject when more than 1 role are provided?
 		for _, role := range details.Roles {
 			if !IsValidRole(role) {
 				return User_error_roles_invalid
 			}
 		}
+	} else {
+		// Defaults to patient if no role is provided
+		details.Roles = []string{"patient"}
 	}
 
 	return nil
@@ -467,7 +476,12 @@ func (u *User) HasRole(role string) bool {
 }
 
 func (u *User) IsClinic() bool {
-	return u.HasRole("clinic")
+	for _, userRole := range u.Roles {
+		if userRole == "hcp" || userRole == "clinic" {
+			return true
+		}
+	}
+	return false
 }
 
 func (u *User) HashPassword(pw, salt string) error {

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -154,7 +154,7 @@ func Test_IsValidRole_Invalid(t *testing.T) {
 }
 
 func Test_IsValidRole_Valid(t *testing.T) {
-	validRoles := []string{"clinic"}
+	validRoles := []string{"hcp", "caregiver"}
 	for _, validRole := range validRoles {
 		if !IsValidRole(validRole) {
 			t.Fatalf("Valid role %s is unexpectedly invalid", validRole)
@@ -229,7 +229,7 @@ func Test_NewUserDetails_ExtractFromJSON_InvalidJSON(t *testing.T) {
 }
 
 func Test_NewUserDetails_ExtractFromJSON_InvalidUsername(t *testing.T) {
-	source := "{\"username\": true, \"emails\": [\"b@y.com\"], \"password\": \"12345678\", \"roles\": [\"clinic\"]}"
+	source := "{\"username\": true, \"emails\": [\"b@y.com\"], \"password\": \"12345678\", \"roles\": [\"hcp\"]}"
 	details := &NewUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_username_invalid {
@@ -241,7 +241,7 @@ func Test_NewUserDetails_ExtractFromJSON_InvalidUsername(t *testing.T) {
 }
 
 func Test_NewUserDetails_ExtractFromJSON_InvalidEmails(t *testing.T) {
-	source := "{\"username\": \"a@z.co\", \"emails\": true, \"password\": \"12345678\", \"roles\": [\"clinic\"]}"
+	source := "{\"username\": \"a@z.co\", \"emails\": true, \"password\": \"12345678\", \"roles\": [\"hcp\"]}"
 	details := &NewUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_emails_invalid {
@@ -253,7 +253,7 @@ func Test_NewUserDetails_ExtractFromJSON_InvalidEmails(t *testing.T) {
 }
 
 func Test_NewUserDetails_ExtractFromJSON_InvalidPassword(t *testing.T) {
-	source := "{\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": true, \"roles\": [\"clinic\"]}"
+	source := "{\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": true, \"roles\": [\"hcp\"]}"
 	details := &NewUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_password_invalid {
@@ -277,13 +277,13 @@ func Test_NewUserDetails_ExtractFromJSON_InvalidRoles(t *testing.T) {
 }
 
 func Test_NewUserDetails_ExtractFromJSON_ValidAll(t *testing.T) {
-	source := "{\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"ignored\": true}"
+	source := "{\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"hcp\"], \"ignored\": true}"
 	details := &NewUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with all: %#v", err)
 	}
-	if *details.Username != "a@z.co" || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || *details.Password != "12345678" || !reflect.DeepEqual(details.Roles, []string{"clinic"}) {
+	if *details.Username != "a@z.co" || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || *details.Password != "12345678" || !reflect.DeepEqual(details.Roles, []string{"hcp"}) {
 		t.Fatalf("Missing fields that should be present on success with all")
 	}
 }
@@ -325,13 +325,13 @@ func Test_NewUserDetails_ExtractFromJSON_ValidPassword(t *testing.T) {
 }
 
 func Test_NewUserDetails_ExtractFromJSON_ValidRoles(t *testing.T) {
-	source := "{\"roles\": [\"clinic\"], \"ignored\": true}"
+	source := "{\"roles\": [\"hcp\"], \"ignored\": true}"
 	details := &NewUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with roles: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || !reflect.DeepEqual(details.Roles, []string{"clinic"}) {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || !reflect.DeepEqual(details.Roles, []string{"hcp"}) {
 		t.Fatalf("Missing fields that should be present on success with roles")
 	}
 }
@@ -407,7 +407,7 @@ func Test_NewUserDetails_Validate_Roles_Invalid(t *testing.T) {
 func Test_NewUserDetails_Validate_Valid(t *testing.T) {
 	username := "a@z.co"
 	password := "12345678"
-	details := &NewUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}}
+	details := &NewUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for valid: %#v", err)
@@ -426,7 +426,7 @@ func Test_ParseNewUserDetails_InvalidJSON(t *testing.T) {
 }
 
 func Test_ParseNewUserDetails_ValidAll(t *testing.T) {
-	source := "{\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"]}"
+	source := "{\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"hcp\"]}"
 	details, err := ParseNewUserDetails(strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with all: %#v", err)
@@ -434,7 +434,7 @@ func Test_ParseNewUserDetails_ValidAll(t *testing.T) {
 	if details == nil {
 		t.Fatalf("Missing details on success with all")
 	}
-	if *details.Username != "a@z.co" || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || *details.Password != "12345678" || !reflect.DeepEqual(details.Roles, []string{"clinic"}) {
+	if *details.Username != "a@z.co" || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || *details.Password != "12345678" || !reflect.DeepEqual(details.Roles, []string{"hcp"}) {
 		t.Fatalf("Missing fields that should be present on success with all")
 	}
 }
@@ -479,7 +479,7 @@ func Test_NewUser_MissingSalt(t *testing.T) {
 func Test_NewUser_Valid(t *testing.T) {
 	username := "a@z.co"
 	password := "12345678"
-	details := &NewUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}}
+	details := &NewUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}}
 	salt := "abc"
 	user, err := NewUser(details, salt)
 	if err != nil {
@@ -494,7 +494,7 @@ func Test_NewUser_Valid(t *testing.T) {
 	if !user.PasswordsMatch(*details.Password, salt) {
 		t.Fatalf("Password does not match on success")
 	}
-	if !reflect.DeepEqual(details.Roles, []string{"clinic"}) {
+	if !reflect.DeepEqual(details.Roles, []string{"hcp"}) {
 		t.Fatalf("Roles do not match on success")
 	}
 	if user.Id == "" || user.Hash == "" {
@@ -772,7 +772,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_MissingUpdates(t *testing.T) {
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidUsername(t *testing.T) {
-	source := "{\"updates\": {\"username\": true, \"emails\": [\"b@y.com\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": true, \"emails\": [\"b@y.com\"], \"password\": \"12345678\", \"roles\": [\"hcp\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_username_invalid {
@@ -784,7 +784,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_InvalidUsername(t *testing.T) {
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidEmails(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": true, \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": true, \"password\": \"12345678\", \"roles\": [\"hcp\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_emails_invalid {
@@ -796,7 +796,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_InvalidEmails(t *testing.T) {
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidPassword(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": true, \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": true, \"roles\": [\"hcp\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_password_invalid {
@@ -820,7 +820,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_InvalidRoles(t *testing.T) {
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidTermsAccepted(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": true, \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"hcp\"], \"termsAccepted\": true, \"emailVerified\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_terms_accepted_invalid {
@@ -832,7 +832,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_InvalidTermsAccepted(t *testing.T) {
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidEmailVerified(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": \"unexpected\"}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"hcp\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": \"unexpected\"}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_email_verified_invalid {
@@ -844,13 +844,13 @@ func Test_UpdateUserDetails_ExtractFromJSON_InvalidEmailVerified(t *testing.T) {
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_ValidAll(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true, \"ignored\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"hcp\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true, \"ignored\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with all: %#v", err)
 	}
-	if *details.Username != "a@z.co" || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || *details.Password != "12345678" || !reflect.DeepEqual(details.Roles, []string{"clinic"}) || *details.TermsAccepted != "2016-01-01T12:00:00-08:00" || !*details.EmailVerified {
+	if *details.Username != "a@z.co" || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || *details.Password != "12345678" || !reflect.DeepEqual(details.Roles, []string{"hcp"}) || *details.TermsAccepted != "2016-01-01T12:00:00-08:00" || !*details.EmailVerified {
 		t.Fatalf("Missing fields that should be present on success with all")
 	}
 }
@@ -892,13 +892,13 @@ func Test_UpdateUserDetails_ExtractFromJSON_ValidPassword(t *testing.T) {
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_ValidRoles(t *testing.T) {
-	source := "{\"updates\": {\"roles\": [\"clinic\"], \"ignored\": true}}"
+	source := "{\"updates\": {\"roles\": [\"hcp\"], \"ignored\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with roles: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || !reflect.DeepEqual(details.Roles, []string{"clinic"}) || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || !reflect.DeepEqual(details.Roles, []string{"hcp"}) || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Missing fields that should be present on success with roles")
 	}
 }
@@ -931,7 +931,7 @@ func Test_UpdateUserDetails_Validate_Username_Missing(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for username missing: %#v", err)
@@ -943,7 +943,7 @@ func Test_UpdateUserDetails_Validate_Username_Invalid(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != User_error_username_invalid {
 		t.Fatalf("Unexpected error for username invalid: %#v", err)
@@ -955,7 +955,7 @@ func Test_UpdateUserDetails_Validate_Emails_Missing(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Password: &password, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for emails missing: %#v", err)
@@ -967,7 +967,7 @@ func Test_UpdateUserDetails_Validate_Emails_Invalid(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c"}, Password: &password, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != User_error_emails_invalid {
 		t.Fatalf("Unexpected error for emails invalid: %#v", err)
@@ -978,7 +978,7 @@ func Test_UpdateUserDetails_Validate_Password_Missing(t *testing.T) {
 	username := "a@z.co"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for password missing: %#v", err)
@@ -990,7 +990,7 @@ func Test_UpdateUserDetails_Validate_Password_Invalid(t *testing.T) {
 	password := "1234567"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != User_error_password_invalid {
 		t.Fatalf("Unexpected error for password invalid: %#v", err)
@@ -1025,7 +1025,7 @@ func Test_UpdateUserDetails_Validate_TermsAccepted_Missing(t *testing.T) {
 	username := "a@z.co"
 	password := "12345678"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for password missing: %#v", err)
@@ -1037,7 +1037,7 @@ func Test_UpdateUserDetails_Validate_TermsAccepted_Invalid(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-13-32T24:65:65-24:30"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != User_error_terms_accepted_invalid {
 		t.Fatalf("Unexpected error for password invalid: %#v", err)
@@ -1048,7 +1048,7 @@ func Test_UpdateUserDetails_Validate_EmailVerified_Missing(t *testing.T) {
 	username := "a@z.co"
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for password missing: %#v", err)
@@ -1060,7 +1060,7 @@ func Test_UpdateUserDetails_Validate_Valid(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"hcp"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for valid: %#v", err)
@@ -1079,7 +1079,7 @@ func Test_ParseUpdateUserDetails_InvalidJSON(t *testing.T) {
 }
 
 func Test_ParseUpdateUserDetails_ValidAll(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"hcp\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
 	details, err := ParseUpdateUserDetails(strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with all: %#v", err)
@@ -1106,8 +1106,8 @@ func Test_User_Email_Missing(t *testing.T) {
 	}
 }
 func Test_User_HasRole_Multiple(t *testing.T) {
-	user := &User{Roles: []string{"clinic", "other"}}
-	if !user.HasRole("clinic") {
+	user := &User{Roles: []string{"hcp", "other"}}
+	if !user.HasRole("hcp") {
 		t.Fatalf("HasRole returned false when should have returned true")
 	}
 	if !user.HasRole("other") {
@@ -1119,8 +1119,8 @@ func Test_User_HasRole_Multiple(t *testing.T) {
 }
 
 func Test_User_HasRole_One(t *testing.T) {
-	user := &User{Roles: []string{"clinic"}}
-	if !user.HasRole("clinic") {
+	user := &User{Roles: []string{"hcp"}}
+	if !user.HasRole("hcp") {
 		t.Fatalf("HasRole returned false when should have returned true")
 	}
 	if user.HasRole("missing") {
@@ -1130,7 +1130,7 @@ func Test_User_HasRole_One(t *testing.T) {
 
 func Test_User_HasRole_Empty(t *testing.T) {
 	user := &User{Roles: []string{}}
-	if user.HasRole("clinic") {
+	if user.HasRole("hcp") {
 		t.Fatalf("HasRole returned true when should have returned false")
 	}
 	if user.HasRole("missing") {
@@ -1140,7 +1140,7 @@ func Test_User_HasRole_Empty(t *testing.T) {
 
 func Test_User_HasRole_Missing(t *testing.T) {
 	user := &User{}
-	if user.HasRole("clinic") {
+	if user.HasRole("hcp") {
 		t.Fatalf("HasRole returned true when should have returned false")
 	}
 	if user.HasRole("missing") {
@@ -1149,7 +1149,7 @@ func Test_User_HasRole_Missing(t *testing.T) {
 }
 
 func Test_User_IsClinic_Valid(t *testing.T) {
-	user := &User{Roles: []string{"clinic"}}
+	user := &User{Roles: []string{"hcp"}}
 	if !user.IsClinic() {
 		t.Fatalf("IsClinic returned false when should have returned true")
 	}
@@ -1281,7 +1281,7 @@ func Test_User_DeepClone(t *testing.T) {
 		Id:            "1234567890",
 		Username:      "a@b.co",
 		Emails:        []string{"a@b.co", "c@d.co"},
-		Roles:         []string{"clinic"},
+		Roles:         []string{"hcp"},
 		TermsAccepted: "2016-01-01T12:34:56-08:00",
 		EmailVerified: true,
 		PwHash:        "this-is-the-password-hash",


### PR DESCRIPTION
A user can now have a role of either:
* patient
* caregiver
* hcp

role defaults to "patient" if no role is provided, just to keep the current process working.