### PR TITLE
Correct shoreline client mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Shoreline is the module that manages logins and user accounts.
 
+## 1.5.1 - 2021-05-03
+### Fixed
+- Correct client mock so it returns the correct role
+
 ## 1.5.0 - 2021-04-13
 ### Changed
 - YLP-549: Authorize caregivers to change their role to "hcp"

--- a/clients/shoreline/shorelineMock.go
+++ b/clients/shoreline/shorelineMock.go
@@ -56,11 +56,13 @@ func (client *ShorelineMockClient) GetUser(userID, token string) (*schema.UserDa
 	if userID == "NotFound" {
 		return nil, nil
 	} else if userID == "WithoutPassword" {
-		return &schema.UserData{UserID: userID, Username: "From Mock", Emails: []string{userID}, PasswordExists: false}, nil
-	} else if strings.Contains(strings.ToLower(userID), "clinic") {
-		return &schema.UserData{UserID: userID, Username: "From Mock", Emails: []string{userID}, PasswordExists: false, Roles: []string{"clinic"}}, nil
+		return &schema.UserData{UserID: userID, Username: "From Mock", Emails: []string{userID}, PasswordExists: false, Roles: []string{"patient"}}, nil
+	} else if strings.Contains(strings.ToLower(userID), "clinic") || strings.Contains(strings.ToLower(userID), "hcp") {
+		return &schema.UserData{UserID: userID, Username: "From Mock", Emails: []string{userID}, PasswordExists: false, Roles: []string{"hcp"}}, nil
+	} else if strings.Contains(strings.ToLower(userID), "caregiver") {
+		return &schema.UserData{UserID: userID, Username: "From Mock", Emails: []string{userID}, PasswordExists: false, Roles: []string{"caregiver"}}, nil
 	} else {
-		return &schema.UserData{UserID: userID, Username: "From Mock", Emails: []string{userID}, PasswordExists: true}, nil
+		return &schema.UserData{UserID: userID, Username: "From Mock", Emails: []string{userID}, PasswordExists: true, Roles: []string{"patient"}}, nil
 	}
 }
 

--- a/clients/shoreline/shorelineMock_test.go
+++ b/clients/shoreline/shorelineMock_test.go
@@ -48,8 +48,8 @@ func TestMock(t *testing.T) {
 	}
 
 	if usr, _ := client.GetUser("a.Clinic@howdy.org", tokenMock); usr != nil {
-		if !contains(usr.Roles, "clinic") {
-			t.Error("Should give us a clinic account")
+		if !contains(usr.Roles, "hcp") {
+			t.Error("Should give us an hcp account")
 		}
 	}
 


### PR DESCRIPTION
Unit tests need a role to be returned by shoreline client mock. Hydrophone for example does not support "clinic" role anymore.
