### PR TITLE
YLP-934 Token creation and renew should use the configured value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 artifact_go.sh
 docs/
 shoreline
+coverReport.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Shoreline is the module that manages logins and user accounts.
 ### Changed
 - YLP-911: put in place metrics in shoreline
 - YLP-919 Yourloops do not encode correctly passwords with special characters
+- YLP-934 Token creation and renew should use the configured value
 
 ## 1.6.1 - 2021-05-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Shoreline is the module that manages logins and user accounts.
 
 ## Unreleased
+### Changed
+- YLP-934 Token creation and renew should use the configured value
 ### Engineering
 - YLP-924 Bump to go-common v1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Shoreline is the module that manages logins and user accounts.
 ### Changed
 - YLP-911: put in place metrics in shoreline
 - YLP-919 Yourloops do not encode correctly passwords with special characters
-- YLP-934 Token creation and renew should use the configured value
 
 ## 1.6.1 - 2021-05-14
 ### Changed

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -30,6 +30,7 @@ RUN /bin/bash -c '/usr/local/bin/docker-entrypoint.sh mongod &' && \
     PATH=$PATH:/go/bin:$(/go/bin/go env GOPATH)/bin bash test.sh && echo 'No Error !' ; \
     sleep 1 && \
     kill "$(ps -C mongod -o pid=)" && \
-    sleep 1
+    sleep 1 && \
+    /bin/cat test-report.xml || /bin/true
 
 ENTRYPOINT ["/bin/cat", "coverReport.html"]

--- a/clients/shoreline/shoreline_client.go
+++ b/clients/shoreline/shoreline_client.go
@@ -62,6 +62,7 @@ func NewShorelineClientBuilder() *ClientBuilder {
 	return &ClientBuilder{
 		config: &ClientConfig{
 			TokenRefreshInterval: jepson.Duration(6 * time.Hour),
+			TokenGetInterval:     time.Duration(time.Duration(10) * time.Second),
 		},
 	}
 }
@@ -175,6 +176,20 @@ func (client *Client) Start() error {
 	return nil
 }
 
+func (client *Client) getNextRefreshInterval() time.Duration {
+	if client.serverToken != "" {
+		tokenData, err := token.ParseUnverified(client.serverToken)
+		if err == nil && tokenData != nil {
+			exp := time.Unix(tokenData.ExpiresAt, 0)
+			now := time.Now()
+			if exp.After(now) {
+				return exp.Sub(now)
+			}
+		}
+	}
+	return time.Duration(client.config.TokenRefreshInterval)
+}
+
 func (client *Client) serverLoginLoop(launchRefreshTokenLoop bool) {
 	var attempts int64
 	client.mut.Lock()
@@ -185,7 +200,7 @@ func (client *Client) serverLoginLoop(launchRefreshTokenLoop bool) {
 	client.acquiringToken = true
 	client.mut.Unlock()
 	for {
-		timer := time.After(time.Duration(client.config.TokenGetInterval))
+		timer := time.After(client.config.TokenGetInterval)
 		select {
 		case twoWay := <-client.closed:
 			twoWay <- true
@@ -201,17 +216,16 @@ func (client *Client) serverLoginLoop(launchRefreshTokenLoop bool) {
 					go client.refreshTokenLoop()
 				}
 				return
-			} else {
-				attempts++
-				log.Printf("Error when getting server token (attempt %v). Error: %v", attempts, err)
 			}
+			attempts++
+			log.Printf("Error when getting server token (attempt %v). Error: %v", attempts, err)
 		}
 	}
 }
 
 func (client *Client) refreshTokenLoop() {
 	for {
-		timer := time.After(time.Duration(client.config.TokenRefreshInterval))
+		timer := time.After(client.getNextRefreshInterval())
 		select {
 		case twoWay := <-client.closed:
 			twoWay <- true
@@ -229,6 +243,8 @@ func (client *Client) refreshTokenLoop() {
 		}
 	}
 }
+
+// Close stop the refresh token loop, must be called when the service is stopped
 func (client *Client) Close() {
 	twoWay := make(chan bool)
 	client.closed <- twoWay

--- a/test.sh
+++ b/test.sh
@@ -5,9 +5,12 @@ go test -v -race -coverprofile=coverage.out ./... 2>&1 > testresults.txt
 testPass=$?
 cat testresults.txt
 cat testresults.txt | go-junit-report  > test-report.xml
+
 if [ $testPass -eq 1 ]; then
   echo "Test failled"
-  exit 1
 fi
+
 gocover-cobertura < coverage.out > coverage.xml
 go tool cover -html='coverage.out' -o coverReport.html
+
+exit $testPass

--- a/token/token.go
+++ b/token/token.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -24,11 +25,13 @@ type (
 	TokenData struct {
 		IsServer     bool   `json:"isserver"`
 		UserId       string `json:"userid"`
-		Email        string `json:"email"`
-		Name         string `json:"name"`
-		Role         string `json:"role"`
-		DurationSecs int64  `json:"-"`
-		Audience     string `json:"audience"`
+		Email        string `json:"email,omitempty"`
+		Name         string `json:"name,omitempty"`
+		Role         string `json:"role,omitempty"`
+		DurationSecs int64  `json:"duration"`
+		ExpiresAt    int64  `json:"-"`
+		Audience     string `json:"audience,omitempty"`
+		JwtID        string `json:"-"`
 	}
 
 	TokenConfig struct {
@@ -45,14 +48,18 @@ const (
 )
 
 var (
-	SessionToken_error_no_userid        = errors.New("SessionToken: userId not set")
-	SessionToken_invalid                = errors.New("SessionToken: is invalid")
-	SessionToken_error_duration_not_set = errors.New("SessionToken: duration not set")
+	errorSessionTokenNoUserID         = errors.New("SessionToken: userId not set")
+	errorSessionTokenEmpty            = errors.New("SessionToken: empty token")
+	errorSessionTokenInvalid          = errors.New("SessionToken: is invalid")
+	errorSessionTokenNoDuration       = errors.New("SessionToken: dur not set")
+	errorSessionTokenExpirationNotSet = errors.New("SessionToken: exp not set")
+	errorSessionTokenUsrNotSet        = errors.New("SessionToken: exp not set")
 )
 
+// UnpackSessionTokenAndVerify verify that the provided token string is valid
 func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
 	if id == "" {
-		return nil, SessionToken_error_no_userid
+		return nil, errorSessionTokenEmpty
 	}
 
 	jwtToken, err := jwt.Parse(id, func(t *jwt.Token) (interface{}, error) { return []byte(secret), nil })
@@ -60,16 +67,36 @@ func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
 		return nil, err
 	}
 	if !jwtToken.Valid {
-		return nil, SessionToken_invalid
+		return nil, errorSessionTokenInvalid
 	}
 
 	claims := jwtToken.Claims.(jwt.MapClaims)
 	isServer := claims["svr"] == "yes"
 	durationSecs, ok := claims["dur"].(int64)
 	if !ok {
-		durationSecs = int64(claims["dur"].(float64))
+		dur64, ok := claims["dur"].(float64)
+		if !ok {
+			return nil, errorSessionTokenNoDuration
+		}
+		durationSecs = int64(dur64)
 	}
-	userId := claims["usr"].(string)
+
+	expiresAt, ok := claims["exp"].(int64)
+	if !ok {
+		var expiresAtFloat float64
+		expiresAtFloat, ok = claims["exp"].(float64)
+		if ok {
+			expiresAt = int64(expiresAtFloat)
+		}
+	}
+	if !ok || expiresAt <= 0 {
+		return nil, errorSessionTokenExpirationNotSet
+	}
+
+	userID, ok := claims["usr"].(string)
+	if !ok {
+		return nil, errorSessionTokenUsrNotSet
+	}
 
 	email, ok := claims["email"].(string)
 	if !ok {
@@ -83,28 +110,30 @@ func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
 	if !ok {
 		role = ""
 	}
+	jti, ok := claims["jti"].(string)
+	if !ok {
+		return nil, errors.New("Missing jti")
+	}
 
 	return &TokenData{
 		IsServer:     isServer,
 		DurationSecs: durationSecs,
-		UserId:       userId,
+		ExpiresAt:    expiresAt,
+		UserId:       userID,
 		Email:        email,
 		Name:         name,
 		Role:         role,
+		JwtID:        jti,
 	}, nil
 }
 
-func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, error) {
+func CreateSessionToken(data *TokenData, config *TokenConfig) (*SessionToken, error) {
 	if data.UserId == "" {
-		return nil, SessionToken_error_no_userid
+		return nil, errorSessionTokenNoUserID
 	}
 
 	if data.DurationSecs == 0 {
-		if data.IsServer {
-			data.DurationSecs = 24 * 60 * 60
-		} else {
-			data.DurationSecs = config.DurationSecs
-		}
+		data.DurationSecs = config.DurationSecs
 	}
 
 	now := time.Now()
@@ -166,4 +195,15 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 	}
 
 	return sessionToken, nil
+}
+
+// ToStringForLog return a string intended to be put in the logs only
+func (tokenData *TokenData) ToStringForLog() string {
+	var tokenType string
+	if tokenData.IsServer {
+		tokenType = "srv"
+	} else {
+		tokenType = "usr"
+	}
+	return fmt.Sprintf("%s{%s}, jti{%s}, dur{%d}, exp{%v}", tokenType, tokenData.UserId, tokenData.JwtID, tokenData.DurationSecs, tokenData.ExpiresAt)
 }

--- a/token/token.go
+++ b/token/token.go
@@ -45,6 +45,7 @@ const (
 	TP_SESSION_TOKEN   = "x-tidepool-session-token"
 	// TP_TRACE_SESSION Session trace: uuid v4
 	TP_TRACE_SESSION = "x-tidepool-trace-session"
+	signAlg          = "HS256"
 )
 
 var (
@@ -53,24 +54,12 @@ var (
 	errorSessionTokenInvalid          = errors.New("SessionToken: is invalid")
 	errorSessionTokenNoDuration       = errors.New("SessionToken: dur not set")
 	errorSessionTokenExpirationNotSet = errors.New("SessionToken: exp not set")
-	errorSessionTokenUsrNotSet        = errors.New("SessionToken: exp not set")
+	errorSessionTokenUsrNotSet        = errors.New("SessionToken: usr not set")
+	errorSessionTokenJtiNotSet        = errors.New("SessionToken: jti not set")
+	errorSessionTokenInvalidSignAlg   = errors.New("SessionToken: invalid sign method")
 )
 
-// UnpackSessionTokenAndVerify verify that the provided token string is valid
-func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
-	if id == "" {
-		return nil, errorSessionTokenEmpty
-	}
-
-	jwtToken, err := jwt.Parse(id, func(t *jwt.Token) (interface{}, error) { return []byte(secret), nil })
-	if err != nil {
-		return nil, err
-	}
-	if !jwtToken.Valid {
-		return nil, errorSessionTokenInvalid
-	}
-
-	claims := jwtToken.Claims.(jwt.MapClaims)
+func parseClaims(claims jwt.MapClaims) (*TokenData, error) {
 	isServer := claims["svr"] == "yes"
 	durationSecs, ok := claims["dur"].(int64)
 	if !ok {
@@ -112,7 +101,7 @@ func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
 	}
 	jti, ok := claims["jti"].(string)
 	if !ok {
-		return nil, errors.New("Missing jti")
+		return nil, errorSessionTokenJtiNotSet
 	}
 
 	return &TokenData{
@@ -127,6 +116,37 @@ func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
 	}, nil
 }
 
+// ParseUnverified just parse the token content, without validating the signature
+func ParseUnverified(id string) (*TokenData, error) {
+	jwtToken, _, err := new(jwt.Parser).ParseUnverified(id, jwt.MapClaims{})
+	if err != nil {
+		return nil, err
+	}
+
+	if jwtToken.Method.Alg() != signAlg {
+		return nil, errorSessionTokenInvalidSignAlg
+	}
+	return parseClaims(jwtToken.Claims.(jwt.MapClaims))
+}
+
+// UnpackSessionTokenAndVerify verify that the provided token string is valid
+func UnpackSessionTokenAndVerify(id string, secret string) (*TokenData, error) {
+	if id == "" {
+		return nil, errorSessionTokenEmpty
+	}
+
+	jwtToken, err := jwt.Parse(id, func(t *jwt.Token) (interface{}, error) { return []byte(secret), nil })
+	if err != nil {
+		return nil, err
+	}
+	if !jwtToken.Valid {
+		return nil, errorSessionTokenInvalid
+	}
+
+	return parseClaims(jwtToken.Claims.(jwt.MapClaims))
+}
+
+// CreateSessionToken generate the signed token string from the provided information
 func CreateSessionToken(data *TokenData, config *TokenConfig) (*SessionToken, error) {
 	if data.UserId == "" {
 		return nil, errorSessionTokenNoUserID
@@ -140,8 +160,8 @@ func CreateSessionToken(data *TokenData, config *TokenConfig) (*SessionToken, er
 	createdAt := now.Unix()
 	expiresAt := now.Add(time.Duration(data.DurationSecs) * time.Second).Unix()
 
-	jwt_token := jwt.New(jwt.GetSigningMethod("HS256"))
-	claims := jwt_token.Claims.(jwt.MapClaims)
+	jwtToken := jwt.New(jwt.GetSigningMethod(signAlg))
+	claims := jwtToken.Claims.(jwt.MapClaims)
 	if data.IsServer {
 		claims["svr"] = "yes"
 	} else {
@@ -175,7 +195,7 @@ func CreateSessionToken(data *TokenData, config *TokenConfig) (*SessionToken, er
 	claims["iat"] = createdAt
 	claims["jti"] = uuid.New()
 
-	tokenString, err := jwt_token.SignedString([]byte(config.Secret))
+	tokenString, err := jwtToken.SignedString([]byte(config.Secret))
 	if err != nil {
 		return nil, err
 	}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -9,7 +9,7 @@ import (
 
 type tokenTestData struct {
 	data   *TokenData
-	config TokenConfig
+	config *TokenConfig
 }
 
 var tokenConfig = TokenConfig{
@@ -21,7 +21,7 @@ func Test_GenerateSessionToken(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 3600},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -61,7 +61,7 @@ func Test_GenerateSessionToken_DurationFromConfig(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 0},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	//given duration seconds trump the configured duration
@@ -82,7 +82,7 @@ func Test_GenerateSessionToken_DurationSecsTrumpConfig(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -103,7 +103,7 @@ func Test_GenerateSessionToken_Zendesk_Claims_Patient(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Audience: "zendesk", Role: "patient"},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -132,7 +132,7 @@ func Test_GenerateSessionToken_Zendesk_Claims_Caregiver(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Audience: "zendesk", Role: "caregiver"},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -161,7 +161,7 @@ func Test_GenerateSessionToken_Zendesk_Claims_Pro(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Audience: "zendesk", Role: "hcp"},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -190,7 +190,7 @@ func Test_GenerateSessionToken_With_UserDetails(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "12-99-100", IsServer: false, DurationSecs: 5000, Email: "user@test.com", Name: "John Doe", Role: "hcp"},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -221,7 +221,7 @@ func Test_GenerateSessionToken_NoUserId(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "", IsServer: false, DurationSecs: 3600},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	if _, err := CreateSessionToken(testData.data, testData.config); err == nil {
@@ -233,7 +233,7 @@ func Test_GenerateSessionToken_Server(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "shoreline", IsServer: true, DurationSecs: 0},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -248,17 +248,16 @@ func Test_GenerateSessionToken_Server(t *testing.T) {
 		t.Fatal("this should be a server token")
 	}
 
-	if td.DurationSecs != 24*60*60 {
-		t.Fatal("the duration should be 24hrs")
+	if td.DurationSecs != tokenConfig.DurationSecs {
+		t.Fatalf("expected token duration %v to be %v ", time.Duration(td.DurationSecs)*time.Second, time.Duration(tokenConfig.DurationSecs)*time.Second)
 	}
-
 }
 
 func Test_UnpackedData(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "111", IsServer: true, DurationSecs: 0, Email: "user@test.com", Name: "John Doe", Role: "hcp"},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -298,7 +297,7 @@ func Test_UnpackTokenExpires(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "2341", IsServer: false, DurationSecs: 1},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -321,7 +320,7 @@ func Test_UnpackAndVerifyStoredToken(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "2341", IsServer: false, DurationSecs: 1200},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
@@ -338,7 +337,7 @@ func Test_getUnpackedToken(t *testing.T) {
 
 	testData := tokenTestData{
 		data:   &TokenData{UserId: "2341", IsServer: false, DurationSecs: 1},
-		config: tokenConfig,
+		config: &tokenConfig,
 	}
 
 	token, _ := CreateSessionToken(testData.data, testData.config)

--- a/user/api.go
+++ b/user/api.go
@@ -111,6 +111,7 @@ const (
 	STATUS_INVALID_USER_DETAILS  = "Invalid user details were given"
 	STATUS_USER_NOT_FOUND        = "User not found"
 	STATUS_ERR_FINDING_USR       = "Error finding user"
+	STATUS_ERR_DELETE_USR        = "Error deleting user"
 	STATUS_ERR_CREATING_USR      = "Error creating the user"
 	STATUS_ERR_UPDATING_USR      = "Error updating user"
 	STATUS_USR_ALREADY_EXISTS    = "User already exists"
@@ -126,8 +127,6 @@ const (
 	STATUS_ERR_SENDING_EMAIL     = "Error sending email"
 	STATUS_NO_TOKEN              = "No x-tidepool-session-token was found"
 	STATUS_SERVER_TOKEN_REQUIRED = "A server token is required"
-	STATUS_AUTH_HEADER_REQUIRED  = "Authorization header is required"
-	STATUS_AUTH_HEADER_INVLAID   = "Authorization header is invalid"
 	STATUS_GETSTATUS_ERR         = "Error checking service status"
 	STATUS_UNAUTHORIZED          = "Not authorized for requested operation"
 	STATUS_NO_QUERY              = "A query must be specified"
@@ -233,6 +232,7 @@ func NewConfigFromEnv(log *log.Logger) *ApiConfig {
 	} else if found {
 		config.TokenDurationSecs = int64(intValue)
 	}
+	log.Printf("Token duration seconds %d", config.TokenDurationSecs)
 
 	salt, found := os.LookupEnv("SALT")
 	if found && len(salt) > 0 {
@@ -401,7 +401,7 @@ func (a *Api) CreateUser(res http.ResponseWriter, req *http.Request) {
 	} else {
 		tokenData := token.TokenData{DurationSecs: extractTokenDuration(req), UserId: newUser.Id, IsServer: false, Role: "unverified"}
 		tokenConfig := token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
-		if sessionToken, err := CreateSessionTokenAndSave(req.Context(), &tokenData, tokenConfig, a.Store); err != nil {
+		if sessionToken, err := CreateSessionTokenAndSave(req.Context(), &tokenData, &tokenConfig, a.Store); err != nil {
 			a.sendError(res, http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err)
 		} else {
 			a.logAudit(req, &tokenData, "CreateUser isClinic{%t}", newUser.IsClinic())
@@ -586,8 +586,8 @@ func (a *Api) GetUserInfo(res http.ResponseWriter, req *http.Request, vars map[s
 	}
 }
 
-// @Summary Delete user
-// @Description Delete user
+// @Summary Delete a user
+// @Description Delete a user
 // @ID shoreline-user-api-deleteuser
 // @Accept  json
 // @Produce  json
@@ -595,55 +595,78 @@ func (a *Api) GetUserInfo(res http.ResponseWriter, req *http.Request, vars map[s
 // @Param password body string true "password"
 // @Security TidepoolAuth
 // @Success 202 "User deleted"
+// @Failure 400 {object} status.Status "message returned:\"Missing id and/or password\" "
+// @Failure 401 {string} status.Status "messages: \"Not authorized for requested operation\""
+// @Failure 403 {object} status.Status "message returned:\"Wrong password\""
+// @Failure 404 {object} status.Status "message returned:\"User not found\" "
 // @Failure 500 {string} string ""
-// @Failure 403 {object} status.Status "message returned:\"Missing id and/or password\" "
-// @Failure 401 {string} string ""
 // @Router /user/{userid} [delete]
 func (a *Api) DeleteUser(res http.ResponseWriter, req *http.Request, vars map[string]string) {
-
 	td, err := a.authenticateSessionToken(req.Context(), req.Header.Get(TP_SESSION_TOKEN))
+	a.logAudit(req, td, "DeleteUser")
 
 	if err != nil {
-		a.logger.Println(http.StatusUnauthorized, err.Error())
-		res.WriteHeader(http.StatusUnauthorized)
+		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, "DeleteUser verify token:", err)
 		return
 	}
 
-	var id string
-	if td.IsServer == true {
-		id = vars["userid"]
-		a.logger.Println("operating as server")
-	} else {
-		id = td.UserId
+	if vars == nil {
+		// Should never happen, but in case, don't crash
+		a.sendError(res, http.StatusInternalServerError, STATUS_NO_QUERY, "DeleteUser: vars is nil")
+		return
 	}
 
-	pw := getGivenDetail(req)["password"]
+	id, ok := vars["userid"]
+	if !ok || id == "" {
+		a.sendError(res, http.StatusBadRequest, STATUS_MISSING_ID_PW, "DeleteUser", "Missing userid in query")
+		return
+	}
 
-	if id != "" && pw != "" {
+	if !td.IsServer && id != td.UserId {
+		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, "DeleteUser: can't delete another user")
+		return
+	}
 
-		var err error
-		toDelete := &User{Id: id}
+	toDelete := &User{Id: id}
 
-		if err = toDelete.HashPassword(pw, a.ApiConfig.Salt); err == nil {
-			if err = a.Store.RemoveUser(req.Context(), toDelete); err == nil {
-
-				a.logAudit(req, td, "DeleteUser")
-				//cleanup if any
-				if td.IsServer == false {
-					a.Store.RemoveTokenByID(req.Context(), req.Header.Get(TP_SESSION_TOKEN))
-				}
-				//all good
-				res.WriteHeader(http.StatusAccepted)
-				return
-			}
+	if !td.IsServer {
+		// A user want to delete it's account: check the password passed in the body
+		pw, ok := a.getGivenDetail(req)["password"]
+		if !ok || pw == "" {
+			a.sendError(res, http.StatusBadRequest, STATUS_MISSING_ID_PW, "DeleteUser", fmt.Sprintf("Missing password in body ok{%v} pw{%v}", ok, pw))
+			return
 		}
-		a.logger.Println(http.StatusInternalServerError, err.Error())
-		res.WriteHeader(http.StatusInternalServerError)
+
+		user, err := a.Store.FindUser(req.Context(), toDelete)
+		if err != nil || user == nil {
+			a.sendError(res, http.StatusNotFound, STATUS_USER_NOT_FOUND, "DeleteUser", err)
+			return
+		}
+
+		if !user.PasswordsMatch(pw, a.ApiConfig.Salt) {
+			a.sendError(res, http.StatusForbidden, STATUS_PW_WRONG, "DeleteUser: Password don't match")
+			return
+		}
+	} // else: Server token do not need to give a password, it can't have it anyway
+
+	// Good, try to delete the user
+	err = a.Store.RemoveUser(req.Context(), toDelete)
+	if err != nil {
+		a.sendError(res, http.StatusInternalServerError, STATUS_ERR_DELETE_USR, "DeleteUser", err)
 		return
 	}
-	a.logger.Println(http.StatusForbidden, STATUS_MISSING_ID_PW)
-	sendModelAsResWithStatus(res, status.NewStatus(http.StatusForbidden, STATUS_MISSING_ID_PW), http.StatusForbidden)
-	return
+
+	// Clean-up user tokens: TODO Delete all user token?
+	if td.IsServer == false {
+		err = a.Store.RemoveTokenByID(req.Context(), req.Header.Get(TP_SESSION_TOKEN))
+		if err != nil {
+			// Just log the error
+			a.logAudit(req, td, "Error while removing the token: %v", err)
+		}
+	}
+
+	// All good
+	res.WriteHeader(http.StatusAccepted)
 }
 
 // @Summary Login user
@@ -710,9 +733,11 @@ func (a *Api) Login(res http.ResponseWriter, req *http.Request) {
 		role := "patient"
 		if result.Roles != nil && len(result.Roles) > 0 {
 			role = result.Roles[0]
+		} else {
+			a.logger.Printf("User role of %s is empty: replaced by role patient", result.Id)
 		}
 		tokenData := &token.TokenData{DurationSecs: extractTokenDuration(req), UserId: result.Id, Email: result.Username, Name: result.Username, Role: role}
-		tokenConfig := token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
+		tokenConfig := &token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
 		if sessionToken, err := CreateSessionTokenAndSave(req.Context(), tokenData, tokenConfig, a.Store); err != nil {
 			a.sendError(res, http.StatusInternalServerError, STATUS_ERR_UPDATING_TOKEN, err)
 
@@ -775,29 +800,27 @@ func (a *Api) ServerLogin(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// If the expected secret is the one given at the door then we can generate a token
-	if pw == expectedSecret {
-		//generate new token
-		if sessionToken, err := CreateSessionTokenAndSave(
-			req.Context(),
-			&token.TokenData{DurationSecs: extractTokenDuration(req), UserId: server, IsServer: true},
-			token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret},
-			a.Store,
-		); err != nil {
-			// Error generating the token
-			a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())
-			sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN), http.StatusInternalServerError)
-			return
-		} else {
-			// Server is provided with the generated token
-			a.logAudit(req, nil, "ServerLogin")
-			res.Header().Set(TP_SESSION_TOKEN, sessionToken.ID)
-			return
-		}
+	if pw != expectedSecret {
+		// If the password given at the door is wrong, we cannot generate the token
+		a.logger.Println(http.StatusUnauthorized, STATUS_PW_WRONG)
+		sendModelAsResWithStatus(res, status.NewStatus(http.StatusUnauthorized, STATUS_PW_WRONG), http.StatusUnauthorized)
+		return
 	}
-	// If the password given at the door is wrong, we cannot generate the token
-	a.logger.Println(http.StatusUnauthorized, STATUS_PW_WRONG)
-	sendModelAsResWithStatus(res, status.NewStatus(http.StatusUnauthorized, STATUS_PW_WRONG), http.StatusUnauthorized)
-	return
+
+	// Generate a new token
+	tokenData := &token.TokenData{UserId: server, IsServer: true}
+	tokenConfig := &token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
+	sessionToken, err := token.CreateSessionToken(tokenData, tokenConfig)
+	if err != nil {
+		// Error generating the token
+		a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())
+		sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN), http.StatusInternalServerError)
+		return
+	}
+
+	// Server is provided with the generated token
+	a.logAudit(req, tokenData, "ServerLogin")
+	res.Header().Set(TP_SESSION_TOKEN, sessionToken.ID)
 }
 
 // @Summary Refresh session
@@ -814,48 +837,57 @@ func (a *Api) ServerLogin(res http.ResponseWriter, req *http.Request) {
 // @Failure 401 {string} string ""
 // @Router /login [get]
 func (a *Api) RefreshSession(res http.ResponseWriter, req *http.Request) {
-	a.logger.Printf("refresh session with trace token %v", req.Header.Get(TP_TRACE_SESSION))
-	td, err := a.authenticateSessionToken(req.Context(), req.Header.Get(TP_SESSION_TOKEN))
+	var err error // be sure to have only one err var declared!
+	traceToken := fmt.Sprintf("traceToken{%s}", req.Header.Get(TP_TRACE_SESSION))
+
+	tokenData, err := a.authenticateSessionToken(req.Context(), req.Header.Get(TP_SESSION_TOKEN))
+	if err != nil {
+		a.logAudit(req, tokenData, "RefreshSession: Authentication failed")
+		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, traceToken, "RefreshSession: Authentication failed", err)
+		return
+	}
+
+	var sessionToken *token.SessionToken
+	tokenConfig := &token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
+
+	if tokenData.IsServer {
+		tokenData.DurationSecs = 0
+		sessionToken, err = token.CreateSessionToken(tokenData, tokenConfig)
+
+	} else {
+		// User token: retrieve User in Db for having last information (role)
+		var user *User
+		user, err = a.Store.FindUser(req.Context(), &User{Id: tokenData.UserId})
+		if err != nil {
+			a.sendError(res, http.StatusInternalServerError, STATUS_ERR_FINDING_USR, traceToken, err)
+			return
+		}
+		if user == nil {
+			a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, traceToken, "RefreshSession: User not found")
+			return
+		}
+
+		// TODO: replace this workaround, there should be only one role when the data is cleaned up
+		role := "patient"
+		if user.Roles != nil && len(user.Roles) > 0 {
+			role = user.Roles[0]
+		} else {
+			a.logger.Printf("User role of %s is empty: replaced by role patient", user.Id)
+		}
+
+		// Refresh token with update user information
+		tokenData = &token.TokenData{UserId: user.Id, IsServer: false, Role: role}
+		sessionToken, err = CreateSessionTokenAndSave(req.Context(), tokenData, tokenConfig, a.Store)
+	}
 
 	if err != nil {
-		a.logger.Println(http.StatusUnauthorized, err.Error())
-		res.WriteHeader(http.StatusUnauthorized)
+		a.sendError(res, http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, traceToken, "RefreshSession: CreateSessionToken")
 		return
 	}
 
-	// retrieve User in Db for having last information (role)
-	user, errUser := a.Store.FindUser(req.Context(), &User{Id: td.UserId})
-	if errUser != nil {
-		a.sendError(res, http.StatusInternalServerError, STATUS_ERR_FINDING_USR, err)
-
-	} else if user == nil {
-		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, "User not found")
-	}
-
-	// Set Role
-	var role string
-	if user.Roles != nil && len(user.Roles) > 0 {
-		role = user.Roles[0]
-	}
-
-	//refresh token with update user information
-	newTokenData := token.TokenData{DurationSecs: extractTokenDuration(req), UserId: user.Id, IsServer: false, Role: role}
-	tokenConfig := token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret}
-	if sessionToken, err := CreateSessionTokenAndSave(
-		req.Context(),
-		&newTokenData,
-		tokenConfig,
-		a.Store,
-	); err != nil {
-		a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())
-		sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN), http.StatusInternalServerError)
-		return
-	} else {
-		a.logAudit(req, td, "Refresh session token with last user information")
-		res.Header().Set(TP_SESSION_TOKEN, sessionToken.ID)
-		sendModelAsRes(res, td)
-		return
-	}
+	a.logAudit(req, tokenData, "RefreshSession: OK")
+	res.Header().Set(TP_SESSION_TOKEN, sessionToken.ID)
+	sendModelAsRes(res, tokenData)
 }
 
 // @Summary Longterm login
@@ -894,32 +926,63 @@ func (a *Api) LongtermLogin(res http.ResponseWriter, req *http.Request, vars map
 }
 
 // @Summary Check server token
-// @Description Check server token
+//
+// @Description Verify the provided token in the URL is valid.
+// Can only be used by a service with a valid server token
+//
 // @ID shoreline-user-api-serverchecktoken
-// @Accept  json
-// @Produce  json
+// @Produce json
+//
 // @Param token path string true "server token to check"
 // @Security TidepoolAuth
-// @Success 200 {object} token.TokenData  "Token details"
-// @Failure 401 {object} status.Status "message returned:\"No x-tidepool-session-token was found\" "
+//
+// @Success 200 {object} token.TokenData "Token details"
+// @Failure 400 {object} status.Status "message returned: \"No x-tidepool-session-token was found\" or \"A query must be specified\""
+// @Failure 401 {object} status.Status "message returned: \"A server token is required\" (invalid token provided in x-tidepool-session-token)"
+// @Failure 403 {object} status.Status "message returned: \"No token matched the given details\" (the token to verify is invalid)"
+//
 // @Router /token/{token} [get]
 func (a *Api) ServerCheckToken(res http.ResponseWriter, req *http.Request, vars map[string]string) {
+	// Only services can check for a valid token
+	// The server token must be in the header (x-tidepool-session-token)
+	// and the token to verify in the URL
 
-	if hasServerToken(req.Header.Get(TP_SESSION_TOKEN), a.ApiConfig.Secret) {
-		td, err := a.authenticateSessionToken(req.Context(), vars["token"])
-		if err != nil {
-			a.logger.Printf("failed request: %v", req)
-			a.logger.Println(http.StatusUnauthorized, STATUS_NO_TOKEN, err.Error())
-			sendModelAsResWithStatus(res, status.NewStatus(http.StatusUnauthorized, STATUS_NO_TOKEN), http.StatusUnauthorized)
-			return
-		}
-		sendModelAsRes(res, td)
+	var err error
+	var tokenDataOfTheService *token.TokenData
+	var tokenDataToValidate *token.TokenData
+
+	tokenOfTheService := req.Header.Get(TP_SESSION_TOKEN)
+	tokenToValidate := vars["token"]
+
+	if tokenOfTheService == "" {
+		a.sendError(res, http.StatusBadRequest, STATUS_NO_TOKEN, "ServerCheckToken")
 		return
 	}
-	a.logger.Println(http.StatusUnauthorized, STATUS_NO_TOKEN)
-	a.logger.Printf("header session token: %v", req.Header.Get(TP_SESSION_TOKEN))
-	sendModelAsResWithStatus(res, status.NewStatus(http.StatusUnauthorized, STATUS_NO_TOKEN), http.StatusUnauthorized)
-	return
+
+	if tokenToValidate == "" {
+		a.sendError(res, http.StatusBadRequest, STATUS_NO_QUERY, "ServerCheckToken")
+		return
+	}
+
+	// Verify tokenDataOfTheService is a server token
+	tokenDataOfTheService, err = a.authenticateSessionToken(req.Context(), tokenOfTheService)
+	if err != nil || tokenDataOfTheService == nil || tokenDataOfTheService.IsServer == false {
+		a.logAudit(req, tokenDataOfTheService, "ServerCheckToken{tokenDataOfTheService}")
+		a.sendError(res, http.StatusUnauthorized, STATUS_SERVER_TOKEN_REQUIRED, "ServerCheckToken")
+		return
+	}
+
+	// Verify the supplied token in the URL
+	tokenDataToValidate, err = a.authenticateSessionToken(req.Context(), tokenToValidate)
+	if err != nil || tokenDataToValidate == nil {
+		a.logAudit(req, tokenDataOfTheService, "ServerCheckToken{tokenDataToValidate}")
+		a.sendError(res, http.StatusForbidden, STATUS_NO_TOKEN_MATCH, "ServerCheckToken")
+		return
+	}
+
+	// No error, everything is in order
+	a.logAudit(req, tokenDataOfTheService, "ServerCheckToken OK (%s)", tokenDataToValidate.ToStringForLog())
+	sendModelAsRes(res, tokenDataToValidate)
 }
 
 // @Summary Logout
@@ -929,18 +992,33 @@ func (a *Api) ServerCheckToken(res http.ResponseWriter, req *http.Request, vars 
 // @Produce  json
 // @Security TidepoolAuth
 // @Success 200 {string} string ""
+// @Failure 400 {object} status.Status "message returned:\"No x-tidepool-session-token was found\""
+// @Failure 401 {object} status.Status "message returned:\"Not authorized for requested operation\""
 // @Router /logout [post]
 func (a *Api) Logout(res http.ResponseWriter, req *http.Request) {
-	if id := req.Header.Get(TP_SESSION_TOKEN); id != "" {
-		if err := a.Store.RemoveTokenByID(req.Context(), id); err != nil {
-			//silently fail but still log it
+	sessionToken := req.Header.Get(TP_SESSION_TOKEN)
+	if sessionToken == "" {
+		a.sendError(res, http.StatusBadRequest, STATUS_NO_TOKEN)
+		return
+	}
+
+	// tokenData, err := a.authenticateSessionToken(req.Context(), token)
+	tokenData, err := token.UnpackSessionTokenAndVerify(sessionToken, a.ApiConfig.Secret)
+	if err != nil {
+		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, "Invalid token", err)
+		return
+	}
+
+	if !tokenData.IsServer {
+		if err := a.Store.RemoveTokenByID(req.Context(), sessionToken); err != nil {
+			// Silently fail but still log it
 			a.logger.Println("Logout was unable to delete token", err.Error())
 		}
 	}
+
 	// otherwise all good
-	a.logAudit(req, nil, "Logout")
+	a.logAudit(req, tokenData, "Logout")
 	res.WriteHeader(http.StatusOK)
-	return
 }
 
 // @Summary AnonymousIdHashPair ?
@@ -971,7 +1049,7 @@ func (a *Api) Get3rdPartyToken(res http.ResponseWriter, req *http.Request, vars 
 
 	secret := ""
 	service := vars["service"]
-	if service == "" {
+	if service == "" || service == "default" {
 		sendModelAsResWithStatus(res, status.NewStatus(http.StatusBadRequest, STATUS_PARAMETER_UNKNOWN), http.StatusBadRequest)
 		return
 	} else {
@@ -996,7 +1074,7 @@ func (a *Api) Get3rdPartyToken(res http.ResponseWriter, req *http.Request, vars 
 	//refresh
 	if sessionToken, err := token.CreateSessionToken(
 		td,
-		token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: secret},
+		&token.TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: secret},
 	); err != nil {
 		a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())
 		sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN), http.StatusInternalServerError)
@@ -1036,6 +1114,9 @@ func (a *Api) sendError(res http.ResponseWriter, statusCode int, reason string, 
 
 	case STATUS_ERR_FINDING_USR:
 		httpErrorCounter.WithLabelValues(STATUS_ERR_FINDING_USR).Inc()
+
+	case STATUS_ERR_DELETE_USR:
+		httpErrorCounter.WithLabelValues(STATUS_ERR_DELETE_USR).Inc()
 
 	case STATUS_ERR_CREATING_USR:
 		httpErrorCounter.WithLabelValues(STATUS_ERR_CREATING_USR).Inc()
@@ -1082,12 +1163,6 @@ func (a *Api) sendError(res http.ResponseWriter, statusCode int, reason string, 
 	case STATUS_SERVER_TOKEN_REQUIRED:
 		httpErrorCounter.WithLabelValues(STATUS_SERVER_TOKEN_REQUIRED).Inc()
 
-	case STATUS_AUTH_HEADER_REQUIRED:
-		httpErrorCounter.WithLabelValues(STATUS_AUTH_HEADER_REQUIRED).Inc()
-
-	case STATUS_AUTH_HEADER_INVLAID:
-		httpErrorCounter.WithLabelValues(STATUS_AUTH_HEADER_INVLAID).Inc()
-
 	case STATUS_GETSTATUS_ERR:
 		httpErrorCounter.WithLabelValues(STATUS_GETSTATUS_ERR).Inc()
 
@@ -1109,28 +1184,6 @@ func (a *Api) sendError(res http.ResponseWriter, statusCode int, reason string, 
 
 	a.logger.Printf("%s:%d RESPONSE ERROR: [%d %s] %s", file, line, statusCode, reason, strings.Join(messages, "; "))
 	sendModelAsResWithStatus(res, status.NewStatus(statusCode, reason), statusCode)
-}
-
-func (a *Api) authenticateSessionToken(ctx context.Context, sessionToken string) (*token.TokenData, error) {
-	if sessionToken == "" {
-		return nil, errors.New("Session token is empty")
-	} else if tokenData, err := token.UnpackSessionTokenAndVerify(sessionToken, a.ApiConfig.Secret); err != nil {
-		return nil, err
-	} else if _, err := a.Store.FindTokenByID(ctx, sessionToken); err != nil {
-		return nil, err
-	} else {
-		return tokenData, nil
-	}
-}
-
-func (a *Api) isAuthorized(tokenData *token.TokenData, userID string) bool {
-	if tokenData.IsServer {
-		return true
-	}
-	if tokenData.UserId == userID {
-		return true
-	}
-	return false
 }
 
 // UpdateUserAfterFailedLogin update the user failed login infos in database

--- a/user/api.go
+++ b/user/api.go
@@ -1002,7 +1002,6 @@ func (a *Api) Logout(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// tokenData, err := a.authenticateSessionToken(req.Context(), token)
 	tokenData, err := token.UnpackSessionTokenAndVerify(sessionToken, a.ApiConfig.Secret)
 	if err != nil {
 		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, "Invalid token", err)

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -61,10 +61,16 @@ var (
 	/*
 	 * users and tokens
 	 */
-	TOKEN_CONFIG  = token.TokenConfig{DurationSecs: FAKE_CONFIG.TokenDurationSecs, Secret: FAKE_CONFIG.Secret}
-	USR           = &User{Id: "123-99-100", Username: "test@new.bar", Emails: []string{"test@new.bar"}}
-	USR_TOKEN, _  = token.CreateSessionToken(&token.TokenData{UserId: USR.Id, IsServer: false, DurationSecs: TOKEN_DURATION}, TOKEN_CONFIG)
-	SRVR_TOKEN, _ = token.CreateSessionToken(&token.TokenData{UserId: "shoreline", IsServer: true, DurationSecs: TOKEN_DURATION}, TOKEN_CONFIG)
+	TOKEN_CONFIG  = &token.TokenConfig{DurationSecs: FAKE_CONFIG.TokenDurationSecs, Secret: FAKE_CONFIG.Secret}
+	USR           = InitPatientUser()
+	USR_PASSWORD  = "the-password"
+	USR_TOKEN, _  = token.CreateSessionToken(&token.TokenData{UserId: USR.Id, IsServer: false}, TOKEN_CONFIG)
+	SRVR_TOKEN, _ = token.CreateSessionToken(&token.TokenData{UserId: "shoreline", IsServer: true}, TOKEN_CONFIG)
+
+	invalidTokenConfig    = &token.TokenConfig{DurationSecs: FAKE_CONFIG.TokenDurationSecs, Secret: "Another secret"}
+	invalidUserToken, _   = token.CreateSessionToken(&token.TokenData{UserId: USR.Id, Role: "hcp", IsServer: false}, invalidTokenConfig)
+	invalidServerToken, _ = token.CreateSessionToken(&token.TokenData{UserId: "invalid-srv", IsServer: true}, invalidTokenConfig)
+
 	/*
 	 * basics setup
 	 */
@@ -76,11 +82,6 @@ var (
 	mockStore = NewMockStoreClient(FAKE_CONFIG.Salt, false, false)
 	shoreline = InitAPITest(FAKE_CONFIG, logger, mockStore)
 	/*
-	 *
-	 */
-	mockNoDupsStore = NewMockStoreClient(FAKE_CONFIG.Salt, true, false)
-	shorelineNoDups = InitAPITest(FAKE_CONFIG, logger, mockNoDupsStore)
-	/*
 	 * failure path
 	 */
 	mockStoreFails = NewMockStoreClient(FAKE_CONFIG.Salt, false, MAKE_IT_FAIL)
@@ -89,6 +90,17 @@ var (
 	responsableStore     = NewResponsableMockStoreClient()
 	responsableShoreline = InitShoreline(FAKE_CONFIG, responsableStore)
 )
+
+func InitPatientUser() *User {
+	user := &User{
+		Id:       "123-99-100",
+		Username: "test@new.bar",
+		Emails:   []string{"test@new.bar"},
+		Roles:    []string{"patient"},
+	}
+	user.HashPassword(USR_PASSWORD, FAKE_CONFIG.Salt)
+	return user
+}
 
 func InitShoreline(config *ApiConfig, store Storage) *Api {
 	config.TokenSecrets["zendesk"] = "zendeskSecret"
@@ -330,10 +342,12 @@ func Test_GetUsers_Error_MissingSessionToken(t *testing.T) {
 	T_ExpectErrorResponse(t, response, 401, "Not authorized for requested operation")
 }
 
-func Test_GetUsers_Error_TokenError(t *testing.T) {
-	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{nil, errors.New("ERROR")}}
+func Test_GetUsers_Error_TokenErrorExpired(t *testing.T) {
+	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, 1)
 	defer T_ExpectResponsablesEmpty(t)
+
+	// Wait 2s the token expires
+	time.Sleep(time.Duration(2) * time.Second)
 
 	headers := http.Header{}
 	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
@@ -354,7 +368,6 @@ func Test_GetUsers_Error_NotServerToken(t *testing.T) {
 
 func Test_GetUsers_Error_InvalidRole(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
 	headers := http.Header{}
@@ -365,7 +378,6 @@ func Test_GetUsers_Error_InvalidRole(t *testing.T) {
 
 func Test_GetUsers_Error_NoQuery(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
 	headers := http.Header{}
@@ -376,7 +388,6 @@ func Test_GetUsers_Error_NoQuery(t *testing.T) {
 
 func Test_GetUsers_Error_InvalidQuery(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
 	headers := http.Header{}
@@ -387,7 +398,6 @@ func Test_GetUsers_Error_InvalidQuery(t *testing.T) {
 
 func Test_GetUsers_Error_FindUsersWithIdsError(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	responsableStore.FindUsersWithIdsResponses = []FindUsersWithIdsResponse{{[]*User{}, errors.New("ERROR")}}
 	defer T_ExpectResponsablesEmpty(t)
 
@@ -441,7 +451,6 @@ func Test_GetUsers_Error_FindUsersWithIdsSuccess(t *testing.T) {
 
 func Test_GetUsers_Error_FindUsersByRoleError(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	responsableStore.FindUsersByRoleResponses = []FindUsersByRoleResponse{{[]*User{}, errors.New("ERROR")}}
 	defer T_ExpectResponsablesEmpty(t)
 
@@ -453,7 +462,6 @@ func Test_GetUsers_Error_FindUsersByRoleError(t *testing.T) {
 
 func Test_GetUsers_Error_FindUsersByRoleSuccess(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	responsableStore.FindUsersByRoleResponses = []FindUsersByRoleResponse{{[]*User{{Id: "0000000000"}, {Id: "1111111111"}}, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
@@ -841,7 +849,6 @@ func Test_UpdateUser_Success_AuthorizedRoles_Caregiver(t *testing.T) {
 
 func Test_UpdateUser_Success_Server_WithoutPassword(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "0000000000", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	responsableStore.FindUserResponses = []FindUserResponse{{&User{Id: "1111111111", Roles: []string{"hcp"}}, nil}}
 	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{}, nil}}
 	responsableStore.UpsertUserResponses = []error{nil}
@@ -860,7 +867,6 @@ func Test_UpdateUser_Success_Server_WithPassword(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "0000000000", true, TOKEN_DURATION)
 	user := &User{Id: "1111111111", Roles: []string{"caregiver"}}
 	user.HashPassword("password", FAKE_CONFIG.Salt)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	responsableStore.FindUserResponses = []FindUserResponse{{user, nil}}
 	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{}, nil}}
 	responsableStore.UpsertUserResponses = []error{nil}
@@ -921,7 +927,7 @@ func Test_GetUserInfo_Error_FindUsersNil(t *testing.T) {
 func Test_GetUserInfo_Error_NoPermissions(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "0000000000", false, TOKEN_DURATION)
 	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
-	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111"}}, nil}}
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{{Id: "1111111111"}}, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
 	headers := http.Header{}
@@ -933,7 +939,7 @@ func Test_GetUserInfo_Error_NoPermissions(t *testing.T) {
 func Test_GetUserInfo_Success_User(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "1111111111", false, TOKEN_DURATION)
 	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
-	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111", Username: "a@z.co", Emails: []string{"a@z.co"}, TermsAccepted: "2016-01-01T01:23:45-08:00", EmailVerified: true, PwHash: "xyz", Hash: "123"}}, nil}}
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{{Id: "1111111111", Username: "a@z.co", Emails: []string{"a@z.co"}, TermsAccepted: "2016-01-01T01:23:45-08:00", EmailVerified: true, PwHash: "xyz", Hash: "123"}}, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
 	headers := http.Header{}
@@ -946,8 +952,7 @@ func Test_GetUserInfo_Success_User(t *testing.T) {
 
 func Test_GetUserInfo_Success_Server(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "0000000000", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
-	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111", Username: "a@z.co", Emails: []string{"a@z.co"}, TermsAccepted: "2016-01-01T01:23:45-08:00", EmailVerified: true, PwHash: "xyz", Hash: "123"}}, nil}}
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{{Id: "1111111111", Username: "a@z.co", Emails: []string{"a@z.co"}, TermsAccepted: "2016-01-01T01:23:45-08:00", EmailVerified: true, PwHash: "xyz", Hash: "123"}}, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
 	headers := http.Header{}
@@ -960,90 +965,262 @@ func Test_GetUserInfo_Success_Server(t *testing.T) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func TestDeleteUser_StatusForbidden_WhenNoPw(t *testing.T) {
+func TestDeleteUser_StatusUnauthorized_WhenNoToken(t *testing.T) {
+	request, _ := http.NewRequest("DELETE", "/", nil)
+	response := httptest.NewRecorder()
+
+	shoreline.SetHandlers("", rtr)
+	shoreline.DeleteUser(response, request, NO_PARAMS)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusUnauthorized, response.Code)
+	}
+}
+
+func TestDeleteUser_StatusUnauthorized_InvalidToken(t *testing.T) {
+	request, _ := http.NewRequest("DELETE", "/", nil)
+	request.Header.Set(TP_SESSION_TOKEN, invalidUserToken.ID)
+	response := httptest.NewRecorder()
+
+	shoreline.SetHandlers("", rtr)
+	shoreline.DeleteUser(response, request, NO_PARAMS)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusUnauthorized, response.Code)
+	}
+}
+
+func TestDeleteUser_StatusUnauthorized_WhenNoUserIdInQuery(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	defer T_ExpectResponsablesEmpty(t)
+
 	request, _ := http.NewRequest("DELETE", "/", nil)
 	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
 	response := httptest.NewRecorder()
 
-	shoreline.SetHandlers("", rtr)
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, NO_PARAMS)
 
-	shoreline.DeleteUser(response, request, NO_PARAMS)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
+	}
+}
 
-	if response.Code != http.StatusForbidden {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusForbidden, response.Code)
+func TestDeleteUser_StatusUnauthorized_WhenAnotherUserIdInQuery(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	defer T_ExpectResponsablesEmpty(t)
+
+	request, _ := http.NewRequest("DELETE", "/", nil)
+	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
+	response := httptest.NewRecorder()
+
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": "invalid-userid"})
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusUnauthorized, response.Code)
+	}
+}
+
+func TestDeleteUser_StatusForbidden_WhenNoBody(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	defer T_ExpectResponsablesEmpty(t)
+
+	var jsonData = []byte{}
+	request, _ := http.NewRequest("DELETE", "/user/"+USR_TOKEN.UserID, bytes.NewBuffer(jsonData))
+	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
+	response := httptest.NewRecorder()
+
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
 	}
 
 	body, _ := ioutil.ReadAll(response.Body)
 
-	if string(body) != `{"code":403,"reason":"Missing id and/or password"}` {
+	expected := fmt.Sprintf(`{"code":%d,"reason":"%s"}`, http.StatusBadRequest, STATUS_MISSING_ID_PW)
+	if string(body) != expected {
+		t.Fatalf("Message given [%s] expected [%s] ", string(body), expected)
+	}
+}
+
+func TestDeleteUser_StatusForbidden_WhenInvalidBody(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	defer T_ExpectResponsablesEmpty(t)
+
+	var jsonData = []byte(`{An invalid JSON]`)
+	request, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
+	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
+	response := httptest.NewRecorder()
+
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
+	}
+
+	body, _ := ioutil.ReadAll(response.Body)
+
+	if string(body) != `{"code":400,"reason":"Missing id and/or password"}` {
+		t.Fatalf("Message given [%s] expected [%s] ", string(body), STATUS_MISSING_ID_PW)
+	}
+}
+
+func TestDeleteUser_StatusForbidden_WhenNoPw(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	defer T_ExpectResponsablesEmpty(t)
+
+	var jsonData = []byte(`{"pwd": 123}`)
+	request, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
+	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
+	response := httptest.NewRecorder()
+
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
+	}
+
+	body, _ := ioutil.ReadAll(response.Body)
+
+	if string(body) != `{"code":400,"reason":"Missing id and/or password"}` {
 		t.Fatalf("Message given [%s] expected [%s] ", string(body), STATUS_MISSING_ID_PW)
 	}
 }
 
 func TestDeleteUser_StatusForbidden_WhenEmptyPw(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	defer T_ExpectResponsablesEmpty(t)
 
 	var jsonData = []byte(`{"password": ""}`)
 	request, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
 	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
 	response := httptest.NewRecorder()
 
-	shoreline.SetHandlers("", rtr)
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
 
-	shoreline.DeleteUser(response, request, NO_PARAMS)
-
-	if response.Code != http.StatusForbidden {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusForbidden, response.Code)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
 	}
 
 	body, _ := ioutil.ReadAll(response.Body)
 
-	if string(body) != `{"code":403,"reason":"Missing id and/or password"}` {
+	if string(body) != `{"code":400,"reason":"Missing id and/or password"}` {
 		t.Fatalf("Message given [%s] expected [%s] ", string(body), STATUS_MISSING_ID_PW)
 	}
 }
 
-func TestDeleteUser_Failure(t *testing.T) {
-
-	var jsonData = []byte(`{"password": "92ggh38"}`)
-	req, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
-	req.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
-	resp := httptest.NewRecorder()
-
-	shorelineFails.SetHandlers("", rtr)
-
-	shorelineFails.DeleteUser(resp, req, NO_PARAMS)
-
-	if resp.Code != http.StatusUnauthorized {
-		t.Fatalf("Expected [%v] and got [%v]", http.StatusUnauthorized, resp.Code)
-	}
-}
-
-func TestDeleteUser_StatusAccepted(t *testing.T) {
+func TestDeleteUser_StatusNotFound_WhenUserNotFound(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	responsableStore.FindUserResponses = []FindUserResponse{{nil, nil}}
+	defer T_ExpectResponsablesEmpty(t)
 
 	var jsonData = []byte(`{"password": "123youknoWm3"}`)
 	request, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
 	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
 	response := httptest.NewRecorder()
 
-	shoreline.SetHandlers("", rtr)
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
 
-	shoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
-
-	if response.Code != http.StatusAccepted {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusAccepted, response.Code)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusNotFound, response.Code)
 	}
 }
 
-func TestDeleteUser_StatusUnauthorized_WhenNoToken(t *testing.T) {
-	request, _ := http.NewRequest("DELETE", "/", nil)
+func TestDeleteUser_StatusNotFound_FindUserError(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	responsableStore.FindUserResponses = []FindUserResponse{{nil, errors.New("store find user random error")}}
+	defer T_ExpectResponsablesEmpty(t)
+
+	var jsonData = []byte(`{"password": "123youknoWm3"}`)
+	request, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
+	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
 	response := httptest.NewRecorder()
 
-	shoreline.SetHandlers("", rtr)
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
 
-	shoreline.DeleteUser(response, request, NO_PARAMS)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusNotFound, response.Code)
+	}
+}
 
-	if response.Code != http.StatusUnauthorized {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusUnauthorized, response.Code)
+func TestDeleteUser_StatusForbidden_PasswdNoMatch(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	responsableStore.FindUserResponses = []FindUserResponse{{USR, nil}}
+	defer T_ExpectResponsablesEmpty(t)
+
+	var jsonData = []byte(`{"password": "123youknoWm3"}`)
+	request, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
+	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
+	response := httptest.NewRecorder()
+
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
+
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusForbidden, response.Code)
+	}
+}
+
+func TestDeleteUser_StatusInternalServerError_ErrDeleteUser(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	responsableStore.FindUserResponses = []FindUserResponse{{USR, nil}}
+	responsableStore.RemoveUserResponses = []error{errors.New("DB error remove user")}
+	defer T_ExpectResponsablesEmpty(t)
+
+	var jsonData = []byte(fmt.Sprintf(`{"password": "%s"}`, USR_PASSWORD))
+	request, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
+	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
+	response := httptest.NewRecorder()
+
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusInternalServerError, response.Code)
+	}
+}
+
+func TestDeleteUser_StatusAccepted_UserToken(t *testing.T) {
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	responsableStore.FindUserResponses = []FindUserResponse{{USR, nil}}
+	responsableStore.RemoveUserResponses = []error{nil}
+	responsableStore.RemoveTokenByIDResponses = []error{errors.New("Ignored DB error while delete token")}
+	defer T_ExpectResponsablesEmpty(t)
+
+	var jsonData = []byte(fmt.Sprintf(`{"password": "%s"}`, USR_PASSWORD))
+	request, _ := http.NewRequest("DELETE", "/", bytes.NewBuffer(jsonData))
+	request.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
+	response := httptest.NewRecorder()
+
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusAccepted, response.Code)
+	}
+}
+
+func TestDeleteUser_StatusAccepted_ServerToken(t *testing.T) {
+	responsableStore.RemoveUserResponses = []error{nil}
+	defer T_ExpectResponsablesEmpty(t)
+
+	request, _ := http.NewRequest("DELETE", "/", nil)
+	request.Header.Set(TP_SESSION_TOKEN, SRVR_TOKEN.ID)
+	response := httptest.NewRecorder()
+
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.DeleteUser(response, request, map[string]string{"userid": USR.Id})
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusAccepted, response.Code)
 	}
 }
 
@@ -1215,7 +1392,7 @@ func TestServerLogin_StatusBadRequest_WhenNoNameOrSecret(t *testing.T) {
 	shoreline.ServerLogin(response, request)
 
 	if response.Code != http.StatusBadRequest {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusBadRequest, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
 	}
 
 	body, _ := ioutil.ReadAll(response.Body)
@@ -1235,7 +1412,7 @@ func TestServerLogin_StatusBadRequest_WhenNoName(t *testing.T) {
 	shoreline.ServerLogin(response, request)
 
 	if response.Code != http.StatusBadRequest {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusBadRequest, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
 	}
 
 	body, _ := ioutil.ReadAll(response.Body)
@@ -1255,7 +1432,7 @@ func TestServerLogin_StatusBadRequest_WhenNoSecret(t *testing.T) {
 	shoreline.ServerLogin(response, request)
 
 	if response.Code != http.StatusBadRequest {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusBadRequest, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
 	}
 
 	body, _ := ioutil.ReadAll(response.Body)
@@ -1276,27 +1453,11 @@ func TestServerLogin_StatusOK(t *testing.T) {
 	shoreline.ServerLogin(response, request)
 
 	if response.Code != http.StatusOK {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusOK, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusOK, response.Code)
 	}
 
 	if response.Header().Get(TP_SESSION_TOKEN) == "" {
 		t.Fatal("The session token should have been set")
-	}
-
-}
-
-func TestServerLogin_Failure(t *testing.T) {
-	req, _ := http.NewRequest("POST", "/", nil)
-	req.Header.Set(TP_SERVER_NAME, "shoreline")
-	req.Header.Set(TP_SERVER_SECRET, THE_SECRET)
-	resp := httptest.NewRecorder()
-
-	shorelineFails.SetHandlers("", rtr)
-
-	shorelineFails.ServerLogin(resp, req)
-
-	if resp.Code != http.StatusInternalServerError {
-		t.Fatalf("Expected [%v] and got [%v]", http.StatusInternalServerError, resp.Code)
 	}
 }
 
@@ -1307,11 +1468,10 @@ func TestServerLogin_StatusUnauthorized_WhenSecretWrong(t *testing.T) {
 	response := httptest.NewRecorder()
 
 	shoreline.SetHandlers("", rtr)
-
 	shoreline.ServerLogin(response, request)
 
 	if response.Code != http.StatusUnauthorized {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusUnauthorized, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusUnauthorized, response.Code)
 	}
 
 	body, _ := ioutil.ReadAll(response.Body)
@@ -1332,7 +1492,7 @@ func TestRefreshSession_StatusUnauthorized_WithNoToken(t *testing.T) {
 	shoreline.RefreshSession(response, request)
 
 	if response.Code != http.StatusUnauthorized {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusUnauthorized, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusUnauthorized, response.Code)
 	}
 }
 
@@ -1342,26 +1502,28 @@ func TestRefreshSession_StatusUnauthorized_WithWrongToken(t *testing.T) {
 	response := httptest.NewRecorder()
 
 	shoreline.SetHandlers("", rtr)
-
 	shoreline.RefreshSession(response, request)
 
 	if response.Code != http.StatusUnauthorized {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusUnauthorized, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusUnauthorized, response.Code)
 	}
 }
 
 func TestRefreshSession_StatusOK(t *testing.T) {
-
-	shoreline.SetHandlers("", rtr)
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{USR_TOKEN, nil}}
+	responsableStore.FindUserResponses = []FindUserResponse{{USR, nil}}
+	responsableStore.AddTokenResponses = []error{nil}
+	defer T_ExpectResponsablesEmpty(t)
 
 	refreshRequest, _ := http.NewRequest("GET", "/", nil)
 	refreshRequest.Header.Set(TP_SESSION_TOKEN, USR_TOKEN.ID)
 	response := httptest.NewRecorder()
 
-	shoreline.RefreshSession(response, refreshRequest)
+	responsableShoreline.SetHandlers("", rtr)
+	responsableShoreline.RefreshSession(response, refreshRequest)
 
 	if response.Code != http.StatusOK {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusOK, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusOK, response.Code)
 	}
 
 	tokenString := response.Header().Get(TP_SESSION_TOKEN)
@@ -1456,7 +1618,7 @@ func Test_LongTermLogin_Error_FindUsersNil(t *testing.T) {
 
 func Test_LongTermLogin_Error_NoPassword(t *testing.T) {
 	authorization := T_CreateAuthorization(t, "a@b.co", "password")
-	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111"}}, nil}}
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{{Id: "1111111111"}}, nil}}
 	responsableStore.UpsertUserResponses = []error{nil}
 	defer T_ExpectResponsablesEmpty(t)
 
@@ -1468,7 +1630,7 @@ func Test_LongTermLogin_Error_NoPassword(t *testing.T) {
 
 func Test_LongTermLogin_Error_PasswordMismatch(t *testing.T) {
 	authorization := T_CreateAuthorization(t, "a@b.co", "MISMATCH")
-	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5"}}, nil}}
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{{Id: "1111111111", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5"}}, nil}}
 	responsableStore.UpsertUserResponses = []error{nil}
 	defer T_ExpectResponsablesEmpty(t)
 
@@ -1480,7 +1642,7 @@ func Test_LongTermLogin_Error_PasswordMismatch(t *testing.T) {
 
 func Test_LongTermLogin_Error_EmailNotVerified(t *testing.T) {
 	authorization := T_CreateAuthorization(t, "a@b.co", "password")
-	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5"}}, nil}}
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{{Id: "1111111111", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5"}}, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
 	headers := http.Header{}
@@ -1491,7 +1653,7 @@ func Test_LongTermLogin_Error_EmailNotVerified(t *testing.T) {
 
 func Test_LongTermLogin_Error_ErrorCreatingToken(t *testing.T) {
 	authorization := T_CreateAuthorization(t, "a@b.co", "password")
-	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5", EmailVerified: true}}, nil}}
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{{Id: "1111111111", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5", EmailVerified: true}}, nil}}
 	responsableStore.AddTokenResponses = []error{errors.New("ERROR")}
 	defer T_ExpectResponsablesEmpty(t)
 
@@ -1503,7 +1665,7 @@ func Test_LongTermLogin_Error_ErrorCreatingToken(t *testing.T) {
 
 func Test_LongTermLogin_Success(t *testing.T) {
 	authorization := T_CreateAuthorization(t, "a@b.co", "password")
-	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111", Username: "a@z.co", Emails: []string{"a@z.co"}, TermsAccepted: "2016-01-01T01:23:45-08:00", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5", EmailVerified: true}}, nil}}
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{{Id: "1111111111", Username: "a@z.co", Emails: []string{"a@z.co"}, TermsAccepted: "2016-01-01T01:23:45-08:00", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5", EmailVerified: true}}, nil}}
 	responsableStore.AddTokenResponses = []error{nil}
 	defer T_ExpectResponsablesEmpty(t)
 
@@ -1533,7 +1695,7 @@ func TestHasServerToken_True(t *testing.T) {
 	shoreline.ServerLogin(response, svrLoginRequest)
 
 	if response.Code != http.StatusOK {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusOK, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusOK, response.Code)
 	}
 
 	if response.Header().Get(TP_SESSION_TOKEN) == "" {
@@ -1573,7 +1735,7 @@ func TestServerCheckToken_StatusOK(t *testing.T) {
 	shoreline.ServerCheckToken(checkTokenResponse, checkTokenRequest, map[string]string{"token": svrTokenToUse})
 
 	if checkTokenResponse.Code != http.StatusOK {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusOK, checkTokenResponse.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusOK, response.Code)
 	}
 
 	if checkTokenResponse.Header().Get("content-type") != "application/json" {
@@ -1597,9 +1759,6 @@ func TestServerCheckToken_StatusOK(t *testing.T) {
 }
 
 func TestServerCheckToken_StatusUnauthorized_WhenNoSvrToken(t *testing.T) {
-
-	//the api
-
 	shoreline.SetHandlers("", rtr)
 
 	request, _ := http.NewRequest("GET", "/", nil)
@@ -1607,14 +1766,14 @@ func TestServerCheckToken_StatusUnauthorized_WhenNoSvrToken(t *testing.T) {
 
 	shoreline.ServerCheckToken(response, request, NO_PARAMS)
 
-	if response.Code != http.StatusUnauthorized {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusUnauthorized, response.Code)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
 	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func TestLogout_StatusOK_WhenNoToken(t *testing.T) {
+func TestLogout_StatusBadRequest_WhenNoToken(t *testing.T) {
 	request, _ := http.NewRequest("POST", "/", nil)
 	response := httptest.NewRecorder()
 
@@ -1622,8 +1781,8 @@ func TestLogout_StatusOK_WhenNoToken(t *testing.T) {
 
 	shoreline.Logout(response, request)
 
-	if response.Code != http.StatusOK {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusOK, response.Code)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusBadRequest, response.Code)
 	}
 }
 
@@ -1638,7 +1797,7 @@ func TestLogout_StatusOK(t *testing.T) {
 	shoreline.Logout(response, request)
 
 	if response.Code != http.StatusOK {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusOK, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusOK, response.Code)
 	}
 }
 
@@ -1673,7 +1832,7 @@ func TestAnonymousIdHashPair_StatusOK(t *testing.T) {
 	shoreline.AnonymousIdHashPair(response, request)
 
 	if response.Code != http.StatusOK {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusOK, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusOK, response.Code)
 	}
 
 	if response.Header().Get("content-type") != "application/json" {
@@ -1708,7 +1867,7 @@ func TestAnonymousIdHashPair_StatusOK_EvenWhenNoURLParams(t *testing.T) {
 	shoreline.AnonymousIdHashPair(response, request)
 
 	if response.Code != http.StatusOK {
-		t.Fatalf("Non-expected status code%v:\n\tbody: %v", http.StatusOK, response.Code)
+		t.Fatalf("Expected [%v] and got [%v]", http.StatusOK, response.Code)
 	}
 
 	if response.Header().Get("content-type") != "application/json" {
@@ -1870,7 +2029,6 @@ func Test_AuthenticateSessionToken_Success_User(t *testing.T) {
 
 func Test_AuthenticateSessionToken_Success_Server(t *testing.T) {
 	sessionToken := T_CreateSessionToken(t, "abcdef1234", true, TOKEN_DURATION)
-	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
 	defer T_ExpectResponsablesEmpty(t)
 
 	tokenData, err := responsableShoreline.authenticateSessionToken(context.Background(), sessionToken.ID)

--- a/user/helpers.go
+++ b/user/helpers.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-
 	"github.com/mdblp/shoreline/token"
 )
 
@@ -49,11 +48,11 @@ func firstStringNotEmpty(strs ...string) string {
 	return ""
 }
 
-//Docode the http.Request parsing out the user details
-func getGivenDetail(req *http.Request) (d map[string]string) {
+// Decode the http.Request parsing out the user details
+func (a *Api) getGivenDetail(req *http.Request) (d map[string]string) {
 	if req.ContentLength > 0 {
 		if err := json.NewDecoder(req.Body).Decode(&d); err != nil {
-			log.Print(USER_API_PREFIX, "error trying to decode user detail ", err)
+			a.logger.Print(USER_API_PREFIX, "error trying to decode user detail ", err)
 			return nil
 		}
 	}
@@ -135,11 +134,11 @@ func (a *Api) logAudit(req *http.Request, tokenData *token.TokenData, format str
 	}
 
 	if tokenData != nil {
-		prefix += fmt.Sprintf("isServer{%t}, ", tokenData.IsServer)
+		prefix += tokenData.ToStringForLog()
 	}
 
 	s := fmt.Sprintf(format, args...)
-	a.auditLogger.Printf("%s%s", prefix, s)
+	a.auditLogger.Printf("%s %s", prefix, s)
 }
 
 func (a *Api) sendUser(res http.ResponseWriter, user *User, isServerRequest bool) {
@@ -221,7 +220,49 @@ func (a *Api) removeUserLoginInProgress(elem *list.Element) {
 	a.loginLimiter.mutex.Unlock()
 }
 
-func CreateSessionTokenAndSave(ctx context.Context, data *token.TokenData, config token.TokenConfig, store Storage) (*token.SessionToken, error) {
+func (a *Api) authenticateSessionToken(ctx context.Context, sessionToken string) (*token.TokenData, error) {
+	if sessionToken == "" {
+		return nil, errors.New("Session token is empty")
+	}
+
+	tokenData, err := token.UnpackSessionTokenAndVerify(sessionToken, a.ApiConfig.Secret)
+	if err != nil {
+		return nil, err
+	}
+
+	if tokenData == nil {
+		// This should never be true, but to be sure
+		return nil, errors.New("Failed to verify the token")
+	}
+
+	if !tokenData.IsServer {
+		// User token search it in the database
+		result, err := a.Store.FindTokenByID(ctx, sessionToken)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			return nil, errors.New("No token found")
+		}
+		if tokenData.UserId != result.UserID {
+			return nil, fmt.Errorf("Token userID do not match token{%s} database{%s}", tokenData.UserId, result.UserID)
+		}
+	}
+
+	return tokenData, nil
+}
+
+func (a *Api) isAuthorized(tokenData *token.TokenData, userID string) bool {
+	if tokenData.IsServer {
+		return true
+	}
+	if tokenData.UserId == userID {
+		return true
+	}
+	return false
+}
+
+func CreateSessionTokenAndSave(ctx context.Context, data *token.TokenData, config *token.TokenConfig, store Storage) (*token.SessionToken, error) {
 	sessionToken, err := token.CreateSessionToken(data, config)
 	if err != nil {
 		return nil, err

--- a/user/helpers_test.go
+++ b/user/helpers_test.go
@@ -267,7 +267,7 @@ func Test_extractTokenDuration(t *testing.T) {
 
 func Test_hasServerToken(t *testing.T) {
 	tokenTestData := &token.TokenData{UserId: "2341", IsServer: true, DurationSecs: 1}
-	tokenTestConfig := token.TokenConfig{DurationSecs: 3600, Secret: "my secret"}
+	tokenTestConfig := &token.TokenConfig{DurationSecs: 3600, Secret: "my secret"}
 
 	token, _ := token.CreateSessionToken(tokenTestData, tokenTestConfig)
 
@@ -278,7 +278,7 @@ func Test_hasServerToken(t *testing.T) {
 
 func Test_hasServerToken_false(t *testing.T) {
 	tokenTestData := &token.TokenData{UserId: "2341", IsServer: false, DurationSecs: 1}
-	tokenTestConfig := token.TokenConfig{DurationSecs: 3600, Secret: "my secret"}
+	tokenTestConfig := &token.TokenConfig{DurationSecs: 3600, Secret: "my secret"}
 
 	token, _ := token.CreateSessionToken(tokenTestData, tokenTestConfig)
 

--- a/user/mongoStoreClient.go
+++ b/user/mongoStoreClient.go
@@ -53,11 +53,10 @@ func (c *Client) UpsertUser(ctx context.Context, user *User) error {
 }
 
 func (c *Client) FindUser(ctx context.Context, user *User) (result *User, err error) {
-
 	if user.Id != "" {
 		opts := options.FindOne()
 		if err = mgoUsersCollection(c).FindOne(ctx, bson.M{"userid": user.Id}, opts).Decode(&result); err != nil {
-			return result, err
+			return nil, err
 		}
 	}
 

--- a/user/mongoStoreClient_test.go
+++ b/user/mongoStoreClient_test.go
@@ -267,7 +267,7 @@ func TestMongoStore_FindUsersById(t *testing.T) {
 func TestMongoStoreTokenOperations(t *testing.T) {
 
 	testing_token_data := &token.TokenData{UserId: "2341", IsServer: true, DurationSecs: 3600}
-	testing_token_config := token.TokenConfig{DurationSecs: 1200, Secret: "some secret for the tests"}
+	testing_token_config := &token.TokenConfig{DurationSecs: 1200, Secret: "some secret for the tests"}
 
 	ctx := context.Background()
 	mc, err := mgoTestSetup()
@@ -287,7 +287,7 @@ func TestMongoStoreTokenOperations(t *testing.T) {
 		t.Fatalf("we could not save the token %v", err)
 	}
 
-	if foundToken, err := mc.FindTokenByID(ctx, sessionToken.ID); err == nil {
+	if foundToken, err := mc.FindTokenByID(ctx, sessionToken.ID); err == nil && foundToken != nil {
 		if foundToken.ID == "" {
 			t.Fatalf("the token string isn't included %v", foundToken)
 		}


### PR DESCRIPTION
- Token creation should use the configured value, not 24h by default
- Renew token should work with server token
- Logout should do standards verification's and correctly set the error counter
- Delete user should not ask for password with a server token
- Delete user should verify the password when called with a user token
- Don't save server token in db
- Make logs more useful