### PR TITLE
YLP-943 check email characters and length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 Shoreline is the module that manages logins and user accounts.
 
-## Unreleased
+## 1.8.0-rc0
+### Changed
+- YLP-943 add basic checks on user email address
+
 ### Engineering
 - YLP-924 Bump to go-common v1
 ### Changed

--- a/user/user.go
+++ b/user/user.go
@@ -142,7 +142,10 @@ func ExtractStringMap(data map[string]interface{}, key string) (map[string]inter
 }
 
 func IsValidEmail(email string) bool {
-	ok, _ := regexp.MatchString(`\A(?i)([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z`, email)
+	if len(email) > 254 {
+		return false
+	}
+	ok, _ := regexp.MatchString(`\A(?i)([^@\s\x60'"<>]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z`, email)
 	return ok
 }
 

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -127,11 +127,19 @@ func Test_ExtractStringMap_Present_NotStringMap(t *testing.T) {
 }
 
 func Test_IsValidEmail_Invalid(t *testing.T) {
-	invalidEmails := []string{"", "a", "a@", "a@z", "a@z.", "a@z.c", ".co", "z.co", "@z.co", "a@b@z.co", "a b@z.co", "a@z$z.co", "a@x#z.co"}
+	invalidEmails := []string{"", "a", "a@", "a@z", "a@z.", "a@z.c", ".co", "z.co", "@z.co", "a@b@z.co", "a b@z.co", "a@z$z.co", "a@x#z.co", "a't@ici.com", "a<!aaa>@b.com", "a`vv@c.com"}
 	for _, invalidEmail := range invalidEmails {
 		if IsValidEmail(invalidEmail) {
 			t.Fatalf("Invalid email %s is unexpectedly valid", invalidEmail)
 		}
+	}
+	aRealyLongEmail := "a.realy-long-local-name-for-an-email@"
+	for i := 0; i < 10; i++ {
+		aRealyLongEmail = aRealyLongEmail + "azertyuiopqsdfghjklmwxcvbn."
+	}
+	aRealyLongEmail = aRealyLongEmail + "com"
+	if IsValidEmail(aRealyLongEmail) {
+		t.Fatalf("Invalid email %s is unexpectedly valid", aRealyLongEmail)
 	}
 }
 


### PR DESCRIPTION
Add a couple of rules following OWASP recomendations

Question: should we be even more strict and only allow the following characters for the local part ? [a-z] [A-Z] [0-9] dashes (-) and dots (.) to avoid issues with latin characters?