### PR TITLE
YLP-1026: Shoreline cannot start with 200 concurrent users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Shoreline is the module that manages user accounts and authentication.
 
+## 1.8.1 - 2021-09-28
+### Fixed
+- YLP-1026: Shoreline cannot start with 200 concurrent users
+
 ## 1.8.0 - 2021-09-15
 ### Changed
 - YLP-943: Add basic checks on user email address

--- a/user/api.go
+++ b/user/api.go
@@ -174,7 +174,7 @@ func NewConfigFromEnv(log *log.Logger) *ApiConfig {
 		config.DelayBeforeNextLoginAttempt = int64(intValue)
 	}
 
-	intValue, found, err = getIntFromEnvVar("USER_MAX_CONCURRENT_LOGIN", 1, math.MaxInt8)
+	intValue, found, err = getIntFromEnvVar("USER_MAX_CONCURRENT_LOGIN", 1, math.MaxInt16)
 	if err != nil {
 		log.Fatal(err)
 	} else if found {


### PR DESCRIPTION
Updated the max value for USER_MAX_CONCURRENT_LOGIN : from 127 to 32767