### PR TITLE
fix/YLP-1065-fix-role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Shoreline is the module that manages user accounts and authentication.
 
+## 1.8.2
+- YLP-1065: Automatically add the role "patient" for login requests coming from private api
+
 ## 1.8.1 - 2021-09-28
 ### Fixed
 - YLP-1026: Shoreline cannot start with 200 concurrent users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 Shoreline is the module that manages user accounts and authentication.
 
 ## 1.8.2
-- YLP-1065: Automatically add the role "patient" for login requests coming from private api
+### Changed
+- YLP-1065: Automatically add the role "patient" for login requests coming from private api.
+- YLP-1057: Allow usage of all characters in passwords, including unicode and whitespace.
 
 ## 1.8.1 - 2021-09-28
 ### Fixed

--- a/user/api.go
+++ b/user/api.go
@@ -672,6 +672,7 @@ func (a *Api) DeleteUser(res http.ResponseWriter, req *http.Request, vars map[st
 // @Failure 400 {object} status.Status "message returned: \"Missing id and/or password\""
 // @Router /login [post]
 func (a *Api) Login(res http.ResponseWriter, req *http.Request) {
+	requestSource := req.Header.Get("X-Backloops-Source")
 	user, password, err := unpackAuth(req.Header.Get("Authorization"))
 	if err != nil {
 		a.sendError(res, http.StatusBadRequest, STATUS_MISSING_ID_PW, err)
@@ -717,7 +718,17 @@ func (a *Api) Login(res http.ResponseWriter, req *http.Request) {
 		a.sendError(res, http.StatusForbidden, STATUS_NOT_VERIFIED)
 
 	} else {
-		// TODO: replace this workaround, there should be only one role when the data is cleaned up
+		// Login succeed:
+		// FIXME, YLP-1065
+		if requestSource == "private" && result.Roles[0] != "patient" {
+			a.logger.Printf("Adding patient role to user %v", result.Id)
+			// Let's add the role patient:
+			result.Roles = []string{"patient", result.Roles[0]}
+			if err := a.Store.UpsertUser(req.Context(), result); err != nil {
+				a.logger.Printf("Login of a non patient user from our private endpoint. Error while adding the role patient: %s", err)
+			}
+		}
+		// FIXME: replace this workaround, we should support multi roles
 		role := "patient"
 		if result.Roles != nil && len(result.Roles) > 0 {
 			role = result.Roles[0]

--- a/user/api.go
+++ b/user/api.go
@@ -107,7 +107,7 @@ const (
 	EXT_SESSION_TOKEN = "x-external-session-token"
 	// TP_TRACE_SESSION Session trace: uuid v4
 	TP_TRACE_SESSION      = "x-tidepool-trace-session"
-	HEADER_REQUEST_SOURCE = "X-Backloops-Source"
+	HEADER_REQUEST_SOURCE = "x-backloops-source"
 
 	STATUS_NO_USR_DETAILS        = "No user details were given"
 	STATUS_INVALID_USER_DETAILS  = "Invalid user details were given"

--- a/user/api.go
+++ b/user/api.go
@@ -106,7 +106,8 @@ const (
 	TP_SESSION_TOKEN  = "x-tidepool-session-token"
 	EXT_SESSION_TOKEN = "x-external-session-token"
 	// TP_TRACE_SESSION Session trace: uuid v4
-	TP_TRACE_SESSION = "x-tidepool-trace-session"
+	TP_TRACE_SESSION      = "x-tidepool-trace-session"
+	HEADER_REQUEST_SOURCE = "X-Backloops-Source"
 
 	STATUS_NO_USR_DETAILS        = "No user details were given"
 	STATUS_INVALID_USER_DETAILS  = "Invalid user details were given"
@@ -672,7 +673,7 @@ func (a *Api) DeleteUser(res http.ResponseWriter, req *http.Request, vars map[st
 // @Failure 400 {object} status.Status "message returned: \"Missing id and/or password\""
 // @Router /login [post]
 func (a *Api) Login(res http.ResponseWriter, req *http.Request) {
-	requestSource := req.Header.Get("X-Backloops-Source")
+	requestSource := req.Header.Get(HEADER_REQUEST_SOURCE)
 	user, password, err := unpackAuth(req.Header.Get("Authorization"))
 	if err != nil {
 		a.sendError(res, http.StatusBadRequest, STATUS_MISSING_ID_PW, err)

--- a/user/mongoStoreClient.go
+++ b/user/mongoStoreClient.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"sort"
 
 	goComMgo "github.com/mdblp/go-common/clients/mongo"
 	"github.com/mdblp/shoreline/token"
@@ -42,9 +41,6 @@ func mgoTokensCollection(c *Client) *mongo.Collection {
 }
 
 func (c *Client) UpsertUser(ctx context.Context, user *User) error {
-	if user.Roles != nil {
-		sort.Strings(user.Roles)
-	}
 	options := options.Update().SetUpsert(true)
 	update := bson.M{"$set": user}
 	// if the user already exists we update otherwise we add


### PR DESCRIPTION
Automatically add the role "patient" for login requests coming from private api.
Set the role "patient" in first position so it used as a default for next logins.