### PR TITLE
New role "admin" for support team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Shoreline is the module that manages user accounts and authentication.
 
+## UNRELEASED 
+### Added
+- New role "admin" processed in our auth middleware
+
 ## 1.9.1 - 2022-03-02
 ### Added
 - YLP-1310 Unbrick handset created with invalid email address

--- a/clients/auth/auth_client.go
+++ b/clients/auth/auth_client.go
@@ -69,6 +69,7 @@ func (l *LocalAuth) AuthMiddleware(authorizeUnverified bool) gin.HandlerFunc {
 			c.Set("userId", token.UserId)
 			c.Set("isPatient", token.Role == "patient")
 			c.Set("isCaregiver", token.Role == "caregiver")
+			c.Set("isAdmin", token.Role == "admin")
 			c.Set("isHCP", token.Role == "hcp")
 			c.Set("isServer", token.IsServer)
 		}

--- a/clients/auth/auth_test.go
+++ b/clients/auth/auth_test.go
@@ -83,6 +83,7 @@ func assertAuthMiddlewareResponse(t *testing.T, tknData *token.TokenData,
 	assert.Equal(t, c.GetString("userId"), tknData.UserId)
 	assert.Equal(t, c.GetBool("isPatient"), tknData.Role == "patient")
 	assert.Equal(t, c.GetBool("isCaregiver"), tknData.Role == "caregiver")
+	assert.Equal(t, c.GetBool("isAdmin"), tknData.Role == "admin")
 	assert.Equal(t, c.GetBool("isHCP"), tknData.Role == "hcp")
 	assert.Equal(t, c.GetBool("isServer"), tknData.IsServer)
 }
@@ -111,6 +112,9 @@ func TestAuthMiddleware_withUnverifiedToken(t *testing.T) {
 	assertAuthMiddlewareResponse(t, &tknData, true, auth, c, w)
 
 	tknData.Role = "caregiver"
+	assertAuthMiddlewareResponse(t, &tknData, true, auth, c, w)
+
+	tknData.Role = "admin"
 	assertAuthMiddlewareResponse(t, &tknData, true, auth, c, w)
 
 	tknData.Role = "hcp"
@@ -150,6 +154,9 @@ func TestAuthMiddleware_withoutUnverifiedToken(t *testing.T) {
 
 	tknData.Role = "hcp"
 	assertAuthMiddlewareResponse(t, &tknData, false, auth, c, w)
+
+	tknData.Role = "admin"
+	assertAuthMiddlewareResponse(t, &tknData, true, auth, c, w)
 
 	tknData.Role = ""
 	tknData.IsServer = true


### PR DESCRIPTION
This role is handled by the auth middleware
This role cannot be granted/set from the api.