### PR TITLE
Modify shoreline client to be used without server tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Shoreline is the module that manages user accounts and authentication.
 ### Added
 - New role "admin" processed in our auth middleware
 
+### Engineering
+- Simplify client lib: we do not want to force client services to use server tokens.
+
 ## 1.9.1 - 2022-03-02
 ### Added
 - YLP-1310 Unbrick handset created with invalid email address

--- a/clients/shoreline/shorelineMock.go
+++ b/clients/shoreline/shorelineMock.go
@@ -79,12 +79,12 @@ func (client *ShorelineMockClient) TokenProvide() string {
 	return args.Get(0).(string)
 }
 
-func (client *ShorelineMockClient) GetUnverifiedUsers() ([]schema.UserData, error) {
+func (client *ShorelineMockClient) GetUnverifiedUsers(token string) ([]schema.UserData, error) {
 	args := client.Called()
 	return args.Get(0).([]schema.UserData), args.Error(1)
 }
 
-func (client *ShorelineMockClient) DeleteUser(userId string) error {
+func (client *ShorelineMockClient) DeleteUser(userId string, token string) error {
 	client.Called(userId)
 	return nil
 }


### PR DESCRIPTION
We should not force client services to use a server token to call shoreline apis