### PR TITLE
YLP-1676: fix user_id parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Shoreline is the module that manages user accounts and authentication.
 
+## 1.9.7 - 2022-07-28
+- YLP-1676: parse the sub field received from auth0 to extract the userid
+
 ## 1.9.6 - 2022-06-15
 ### Fixed
 - YLP-1610: get a tidepool session token from auth0 token, usefull during migration

--- a/auth0/client.go
+++ b/auth0/client.go
@@ -230,8 +230,15 @@ func (client *Auth0Client) GetUser(email string) (*schema.UserData, error) {
 	if len(users) == 0 {
 		return nil, nil
 	}
+	// extract the user id from the sub field which follows pattern auth0|userid
+	userId := users[0].UserId
+	sub := strings.Split(userId, "|")
+
+	if len(sub) == 2 {
+		userId = sub[1]
+	}
 	user := &schema.UserData{
-		UserID:        users[0].UserId,
+		UserID:        userId,
 		Username:      users[0].Email,
 		EmailVerified: users[0].EmailVerified,
 		Emails:        []string{users[0].Email},
@@ -255,16 +262,23 @@ func (client *Auth0Client) GetUserById(id string) (*schema.UserData, error) {
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.New("Error while requesting Auth0: " + res.Status)
 	}
-	var users auth0User
-	if err := json.NewDecoder(res.Body).Decode(&users); err != nil {
+	var auth0User auth0User
+	if err := json.NewDecoder(res.Body).Decode(&auth0User); err != nil {
 		return nil, err
 	}
+	// extract the user id from the sub field which follows pattern auth0|userid
+	userId := auth0User.UserId
+	sub := strings.Split(userId, "|")
+
+	if len(sub) == 2 {
+		userId = sub[1]
+	}
 	user := &schema.UserData{
-		UserID:        users.UserId,
-		Username:      users.Email,
-		EmailVerified: users.EmailVerified,
-		Emails:        []string{users.Email},
-		Roles:         []string{users.Metadata.Role},
+		UserID:        userId,
+		Username:      auth0User.Email,
+		EmailVerified: auth0User.EmailVerified,
+		Emails:        []string{auth0User.Email},
+		Roles:         []string{auth0User.Metadata.Role},
 	}
 	return user, nil
 }

--- a/auth0/client.go
+++ b/auth0/client.go
@@ -230,13 +230,7 @@ func (client *Auth0Client) GetUser(email string) (*schema.UserData, error) {
 	if len(users) == 0 {
 		return nil, nil
 	}
-	// extract the user id from the sub field which follows pattern auth0|userid
-	userId := users[0].UserId
-	sub := strings.Split(userId, "|")
-
-	if len(sub) == 2 {
-		userId = sub[1]
-	}
+	userId := parseAuth0Sub(users[0].UserId)
 	user := &schema.UserData{
 		UserID:        userId,
 		Username:      users[0].Email,
@@ -266,13 +260,7 @@ func (client *Auth0Client) GetUserById(id string) (*schema.UserData, error) {
 	if err := json.NewDecoder(res.Body).Decode(&auth0User); err != nil {
 		return nil, err
 	}
-	// extract the user id from the sub field which follows pattern auth0|userid
-	userId := auth0User.UserId
-	sub := strings.Split(userId, "|")
-
-	if len(sub) == 2 {
-		userId = sub[1]
-	}
+	userId := parseAuth0Sub(auth0User.UserId)
 	user := &schema.UserData{
 		UserID:        userId,
 		Username:      auth0User.Email,
@@ -346,4 +334,14 @@ func (client *Auth0Client) GetUserInfo(authHeader string) (*schema.UserData, err
 		Emails:        []string{user.Email},
 	}
 	return resUser, nil
+}
+
+// Extract the user id from the sub field which follows pattern auth0|userid
+func parseAuth0Sub(userId string) string {
+	sub := strings.Split(userId, "|")
+
+	if len(sub) == 2 {
+		userId = sub[1]
+	}
+	return userId
 }


### PR DESCRIPTION
Auth0 always return the user_id prefixed with "auth0|". Need to parse the value before using it